### PR TITLE
Build the PO files for wesnoth-tdg

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -20,9 +20,9 @@ set(NORMAL_DOMAINS
 	wesnoth-sota
 	wesnoth-sotbe
 	wesnoth-tb
+	wesnoth-tdg
 	wesnoth-thot
 	wesnoth-tools
-	wesnoth-tdg
 	wesnoth-trow
 	wesnoth-tsg
 	wesnoth-tutorial

--- a/po/wesnoth-tdg/LINGUAS
+++ b/po/wesnoth-tdg/LINGUAS
@@ -1,0 +1,1 @@
+af ang@latin ar bg bn ca ca_ES@valencia cs cy da de el en_GB en@shaw es es_419 eo et eu fi fr ga gd gl grc he hr hu id is it ja ko la lt lv mk mr my nl nb_NO pl pt pt_BR racv ro ru sk sl sr sr@ijekavian sr@ijekavianlatin sr@latin sv tl tr uk vi zh_CN zh_TW

--- a/po/wesnoth-tdg/af.po
+++ b/po/wesnoth-tdg/af.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: af\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/ang@latin.po
+++ b/po/wesnoth-tdg/ang@latin.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ang@latin\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/ar.po
+++ b/po/wesnoth-tdg/ar.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ar\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/bg.po
+++ b/po/wesnoth-tdg/bg.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: bg\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/bn.po
+++ b/po/wesnoth-tdg/bn.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: bn\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/ca.po
+++ b/po/wesnoth-tdg/ca.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ca\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/ca_ES@valencia.po
+++ b/po/wesnoth-tdg/ca_ES@valencia.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ca_ES@valencia\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/cs.po
+++ b/po/wesnoth-tdg/cs.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: cs\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/cy.po
+++ b/po/wesnoth-tdg/cy.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: cy\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/da.po
+++ b/po/wesnoth-tdg/da.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: da\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/de.po
+++ b/po/wesnoth-tdg/de.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/el.po
+++ b/po/wesnoth-tdg/el.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: el\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/en@shaw.po
+++ b/po/wesnoth-tdg/en@shaw.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en@shaw\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/en_GB.po
+++ b/po/wesnoth-tdg/en_GB.po
@@ -1,0 +1,10207 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en_GB\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr "The Deceiver’s Gambit"
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr "1x enemies, 70% xp"
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr "Easy"
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr "2x enemies, 90% xp"
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr "Normal"
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr "4x enemies, 100% xp"
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr "Hard"
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr "4x enemies, less gold"
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr "Deadly"
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr "Campaign Design"
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr "Setting and Story"
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr "Miscellaneous Graphics"
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr "<span size='x-small'>Miss</span>"
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr "TDG"
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr "(Intermediate level, 7 scenarios.)"
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr "The Deceiver’s Gambit II"
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr "(Complex campaign, 8 scenarios.)"
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr "Blast the fire elementals in '<i>Graduation</i>'."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr "Scenario 0: Sandbagger"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+"Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr "Scenario 1: Goblinitarian"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr "Scenario 2: Bloodthirsty"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr "Scenario 3: Mellon"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr "Drown the silverback in '<i>The Sylvan Seer</i>'."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr "Scenario 4: Gurgle gurgle"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr "Scenario 5: Hook, Line, and Sinker"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr "Scenario 6: Royal Privilege"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr "Complete '<i>The Great River</i>' in 20 turns or less."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr "Scenario 7: On the Clock"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr "Scenario 8: Monster in the Mist"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr "Complete '<i>Omaranth</i>' before turns run out."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr "Scenario 9: Sapper"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr "Scenario 10: Army of the Dead"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr "Scenario 11: Combined Arms"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr "Destroy all villages in '<i>The Traitor</i>'."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr "Scenario 12: Scorched Earth"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr "Scenario 13: Stand Fast"
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr "Scenario 14: Armchair General"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr "Magic Missile"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr "Shield"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr "Panacea"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr "Animate Mud"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr "Chill Touch"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr "Levitate"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr "Find Familiar"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr "Mnemonic"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr "Fireball"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr "Siphon"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr "Blizzard"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr "Counterspell"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr "Polymorph"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr "Glamour"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr "Dancing Daggers"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr "Enthrall"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr "Animate Fire"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr "Contingency"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr "Chain Lightning"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr "Time Dilation"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr "Cataclysm"
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr "Cast Delfador’s Spells"
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr "Select Delfador’s Spells"
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr "Cast the Apprentice’s Spells"
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr "Select the Apprentice’s Spells"
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr "Choose Later"
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr "Graduation"
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr "Apprentice"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr "Isle of Alduin"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr "Summoned Monsters"
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr "Leollyn"
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr "Zero upkeep."
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr "Saegwylyn"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr "The Author"
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr "Faster, faster! The wraiths will soon be upon you!"
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr "Just hurry and get to the dispel orb!"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr "Reach the blue orb at the east edge of the map"
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr "Death of the Apprentice"
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr "The wraiths are catching up! Keep moving!"
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr "10 copper says he tries to firebolt them again..."
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr "Casting Spells:"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr "Double- or right-click on the apprentice to cast spells."
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr "All right, all right! It’s just as you said."
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr "10 more copper for me!"
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+"So he does know proper magic after all. It only took four failed exams..."
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr "Hello, my adoring fans!"
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr "Hey, what’re you doing! This isn’t the normal route!"
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr "We’d better get out of here. Remember what happened on his last exam?"
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr "<span color='#ffffff' size='x-small'>Contingency</span>"
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr "Look at me, I made it! This time just has to be good enough!"
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr "<span size='small'>Well, what do you think?</span>"
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr "Apprentice! Are you listening? I’m trying to congratulate you!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr "But who— what— um, yes, I must have drifted off."
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr "Oh no! Master, help!"
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr "I’ll save you!"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr "Stirrings of War"
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr "Ozgob"
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr "Clan Whitefang"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr "Weldyn"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr "15 gold"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr "Treasure! Looks like a previous victim of the goblins."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr "Are we there yet?"
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr "They’re here, they’re here! Humans on the clan road!"
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr "—then grab your spear, you loathsome lout! Time to do our jobs!"
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr "No, no, no! No fight! I run away!"
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr "Why you runtish, yellow—"
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr "Wait for me!"
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr "Run away across the river!"
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr "I said FORM RANKS! Rousers, get these runts organized!"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr "Gumpnug"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr "Bork"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr "Mirnik"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr "Gump"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr "Defeat Ozgob"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr "Death of Methor or the Apprentice"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr "Choosing Spells:"
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr "New Recruit:"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr "$unit.name’s dead! Run away!"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr "Run for your lives!"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr "$unit.name’s dead! Run back across the river!"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr "Noooo, $unit.name! I don’t want to die too!"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr "Run away, $unit.name’s dead!"
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr "Cowards!! Fight and die like real orcish warriors!"
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr "Run away!"
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr "Useless... goblins..."
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr "Now I’ll never make a name for myself..."
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr "Fort Garard"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr "Whitefang Orcs"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr "Khavur"
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr "Too many humans!"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr "Army of Wesnoth"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr "Ushnug"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr "Gusush"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr "Vidrug"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr "Defeat Khavur, the goblin leader"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr "Win before Garard defeats the orcish leader"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr "Garard defeats Vidrug, the orcish leader"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr "Death of Delfador or Methor"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr "Death of Garard or Lionel"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr "New Recruits:"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr "Sun so bright! Wwwait for dark."
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr "Yes! We got another one!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr "I’ve defeated so many orcs; surely the king must be impressed by now!"
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr "Nooo! Help meeee..."
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr "Thorum restro targa thorum..."
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr "Delfador"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr "Bah... my kin will avenge me..."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr "Now I’ll never impress the king..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr "He’s going on without us! Now I’ll never impress the king..."
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr "The Ambassador"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr "Wild Beasts"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr "Woses"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr "Lintanir"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr "Meet Wesnoth‘s ambassador"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr "Death of Delfador"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr "This hollow tree is full of bats!"
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr "What the— did that tree just move?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr "Move Delfador to the north edge of the forest"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr "Do not kill any woses"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr "Death of any wose"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr "Death of Delfador or Deoran"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr "Ack! It‘s one of them!"
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr "The Sylvan Seer"
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr "Dusk"
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr "Eloreis"
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr "Parandra"
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr "Kalenz"
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr "Chantal"
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr "Ok, yes, but—"
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr "Ah, actually—"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr "Truly, a moving speech..."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr "And so do and so shall I. Come, follow me."
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr "Midnight"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr "Look out! There’re beasts in the forest!"
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr "Find the Sylph"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr "Death of Delfador, Deoran, Chantal, or Kalenz"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr "Kalenz and Chantal will not follow you to the next scenario."
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr "There lies the mirror pool, but it is strangely dry..."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr "Fill the central pool with water"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr "Play the puzzle <i>(includes XP)</i>"
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr "Skip the puzzle"
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr "Look, the stream is changing direction!"
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr "Moonstones! Elende, what have you been up to..."
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr "Odd, the water appears shallow but the beast has vanished entirely."
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr "<i>Gurgle gurgle gurgle...</i>"
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr "There! The pool is full!"
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr "Void"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr "What was that?!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr "Elende!"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr "Elende, I come with friends, seeking foresight! Deoran and Del-"
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr "Deoran"
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr "Deoran, is that... you? You look so much younger."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr "What’s going on?! Kalenz, is this normal?"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr "Defeat all enemies"
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr "Loss of Delfador"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr "Hey, stop—"
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr "Dawn"
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr "I didn’t get to finish hearing everything..."
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr "That was long ago, Elende! This is about the humans’ story, not mine."
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr "Chantal—"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr "Elende"
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr "But, what? I don’t understa—"
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr "—nd what you’re saying..."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr "The Deceiver"
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr "Shogro"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr "Khovak"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr "These orcs were sitting on some gold! We can put it to better use."
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr "{ON_DIFFICULTY4 115 115 115 85} gold"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr "Captain Kestrel"
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr "Deepest apologies my Lord, but they are not. Lintanir—"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr "Defeat Khovak, the orcish warlord"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr "Death of Garard, Arand, Lionel, or Methor"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr "There’s more of them coming from the north!"
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr "Deal with it yourself, worm! I’m sticking to the plan."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr "Up yours, pink-skin!"
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr "Stinking Ushka’e! This was a terrible plan..."
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr "Human dogs! You’ve just sealed your deaths..."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr "Run for the hills!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr "Yes! Did I do well, Your Majesty?"
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr "What, huh? How can you tell?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr "Ring of Swords"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr "Ghazgir"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr "Muhku"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr "Irbirch"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr "Blackcrest Orcs"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr "Ssisaix"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr "Blackcrest Saurians"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr "Xairr"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr "Chief Ushka'e"
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr "Bazur"
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr "Survive until turns run out"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr "Defeat Irbirch, recapturing queen Asheviere"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr "Fail to rescue Asheviere before turns run out"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr "Death of Garard, Asheviere, or Methor"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr "They ssstill sssurvive! Thisss was not the plan!"
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr "Quiet, both of you! If I wanted your advice I would have asked for it!"
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr "Coward! Stand and fight!"
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr "Finish off their king, lizard! I’ll handle things here."
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr "Come to ransom back your queen? Too bad, she’s mine!"
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr "Thank yo—"
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr "Not now, milady! We have to get you out of here!"
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr "Garard, I—"
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr "Now now, woman! I have a battle to fight!"
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr "I’m not dying! Just... need a moment..."
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr "Nooo! Help meeee!"
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr "Ssssuch ssssskill!"
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr "Cursessss, I am sssslain!"
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr "I’m sorry, there’s no time! We have to get the king out of here!"
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr "Sir, look out!"
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr "<b><i>NNnrgh!</i></b>"
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr "Now c’mon sir, we’re gettin’ you home."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr "The Great River"
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr "Delfador’s Hirelings"
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr "Ysaxis"
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr "Clan Blackcrest"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr "Fish (and Beacon)"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr "Mount Oromore"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr "Lynyan"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr "Ritharran"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr "Alright men—"
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr "And wom’n!"
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr "Oh."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr "Destroy the signal beacon without raising the alarm"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr "An enemy sees you during their turn"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr "Moving past or killing enemies on your turn will not raise the alarm."
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr "Fog and Vision:"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr "Urk—"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr "We must move swiftly! The fog is already starting to clear."
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr "Look, it’s that wizard again! Light the fire, sound the alarm!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr "The beacon is destroyed! And just in time too: the fog is lifting."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr "I’ve tarried too long, the fog is already clearing!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr "I sssaid, light the fire!"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr "Eeek! It’s gone!"
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr "Defeat enemies before any escape"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr "Any enemy reaches the west edge of the map"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr "I have essscaped!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr "<i>Yaawwnn</i> ...what’s all this noise about?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr "Cursssesss..."
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr "Ah-ha, got you!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr "Weldyn Court"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr "My Liege, I fear you give insufficient weight to—"
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr "Hold your peace, exile. Your king is speaking."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr "(bows)"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr "No offense, boy."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr "(scowls)"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+"Still, these rumors cannot be taken lightly. Something must be done...."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr "Ruins of Saurgrath"
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr "aged"
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr "female^aged"
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr "Fliiss"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr "Messata"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr "Anazz"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr "Zilnaza"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr "Ka'Kzaesz"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr "Fritrais"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr "Artrax"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr "Saurian Juveniles"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr "You’re almost there! Jus’ a lil bit further... almost..."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr "Rendezvous with $companion_name’s guides"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr "Hey, what—"
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr "Gonnin"
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr "Milyn"
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr "Barin"
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr "Pay up ($fee gold)"
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr "Attack"
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr "Whoah, hey uh, what’s going on?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr "Defeat the bandits"
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr "Ughhh..."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr "I’m gettin’ out o’ here!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr "..."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr "The monssstersss hunt usss for sssport! Flee, flee!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr "Who are you! Why bring death into my homesss..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr "fireball"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr "(There we go. Both power and control.)"
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr "Everyone, keep moving! We’re running out of time."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr "Field Hospital"
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr "Oh? You’ve been pulled back from the front?"
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr "I’m loyal, Methor. Always have been, always will be."
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr "Omaranth"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr "Omaranth’s Flight"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr "Fauna"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr "{ON_DIFFICULTY4 60 60 60 30} gold"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr "Move $saurian_guide_name to the marked hex"
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr "Death of $saurian_guide_name"
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr "$saurian_guide_name will not follow you to the next scenario."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr "Us females? Err, yes, that’s right."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr "Oh Great One! Sssave me!"
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr "We must keep moving."
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr "The cold chillsss me ssso! I cannot sssurvive much longer!"
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr "Ssso... cccold... Oh Great One, I have failed you..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr "Well?"
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr "After all, the heroes of old used to slay dragons all the time, right?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr "Uh oh."
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr "Hey, get back here!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr "Relax. What could go wrong?"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr "Brrr... It’s suddenly so c-c-cold..."
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr "Uhh, hello? Who’s there? Boss, is that you?"
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr "Aaaah!"
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr "Protect Delfador’s cave entrance until turns run out"
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr "Delfador’s cave entrance is destroyed"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr "Destroy hostile cave entrances to trap enemies inside."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr "RraaaAAARRRGGG!"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr "C’mon, don’t give up! We can pull through this!"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr "Wha— what’s happening!?"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr "Thank the gods! It’s finally over."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr "I’m alive... I can’t believe it..."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr "I think we won! ...but how?"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr "The center crypt’s collapsin’! We’ve failed!"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr "Houses of the Dead"
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr "Meanwhile..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr "...I suppose we’ll have to do this the hard way."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr "Find Omaranth"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr "In this scenario, you can neither gain nor spend gold."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr "A drakish tomb? This looks ominous..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr "My mind... is my own..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr "Aethyr"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr "Find Iliah-Malal"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr "Allied ghosts will not follow you to the next scenario."
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr "<span color='#008800' size='x-small'>Ghost Captured</span>"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr "Sythan"
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr "It was all a lie. I became only his slave."
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr "Vellin Ka"
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr "Hagha-Tan"
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr "You are no lord of mine, man of Wesnoth. I serve only my clan."
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr "Melinna"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr "Open the gate"
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr "Wait"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr "NOW, YOU DIE."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr "Defeat Omaranth"
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr "Ah ha, ha ha ha..."
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+"Bah, remain a fool, then. You will not find me so easily broken either."
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr "Powers of darkness, confound my foes!"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr "Find and defeat Iliah-Malal, before his undead overwhelm you"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr "Nice try, Delfador! You’ve only destroyed another illusion."
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr "Shadows consume you!"
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr "I should... have kept... my potion..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr "From the dead I came, and to the dead I return..."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr "Rock and dust, bone and stone..."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr "Avenge my flight..."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr "Good luck, Delfador... Don’t trust anyone..."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr "Elensefar Outskirts"
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr "Now if you’ll excuse me, warmonger, I have a city to govern."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr "Damn his cowardace! Still no word from Lionel?"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr "(stares)"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr "Speak UP, boy! I raised you to be a killer, not a coward!"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr "<span size='x-small'>You hardly raised me at all...</span>"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr "Galcadar"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr "Saurian Defectors"
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr "Chief Ghuvog"
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr "Yesss, we mussst fight! Fight the orcsss!"
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr "For the sake of Wesnoth, we cannot fail."
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr "Defeat Ghuvog, the Blackcrest war-chief"
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr "Urgh... how did this massacre happen..."
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr "Now that’s more like it! Fall into line and get ready to fight."
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr "You betray the Great One... the stars shall bring your doom..."
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr "Out of my face, worms!"
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr "You heard the king; form up, and prepare to storm the front!"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr "Death of Garard"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr "Huh."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr "Whaddid you say, boss?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr "Revelry"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr "Moreth"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr "Three cheers for Delfador, hero of the Abez!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr "Three cheers— three cheers for Delfador the Great! Hurrah!"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr "Hurrah for Delfador!"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr "Hooray for Delfador!"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr "Hurrah for Del— *hic* Delfador!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr "For the first time in a long time, all is finally well with the world."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr "*Yawn*"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr "Oh!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr "Hello Delfador — or should I say, “Delfador the Great.”"
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr "Err... I’m not sure I follow, your highness—"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr "Hmph."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr "<span size='x-small'>Father.</span>"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr "<span size='x-small'>It’s about your—</span>"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr "...father, it’s uncle. Prince Arand."
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr "Arand tried to kill me, father. He’s coming for you next."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr "Garard—?"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr "<b><i>WHAT!?</i></b>"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr "My king, what’s going on? I couldn’t help but overhear some of—"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr "Delfador."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr "...err look, m’lord, maybe Deoran’s right abou—"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr "I want you to think very, very carefully before you answer."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr "Sir Kaylan"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr "Delfador, if you would but—"
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr "The Traitor"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr "Royal Cavalry"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr "Luraery"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr "Aelyn"
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr "Fall back! Hold the walls, protect the fort!"
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr "Defeat Prince Arand"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr "Sorry about this!"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr "Fight on without me, friends! Fight for our king!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+"Welcome to Garard’s Wold, last civilized town north of the Great River."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr "Such devastation. Garard’s orders have been followed to the letter..."
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr "Help, help! What’s going on!"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr "But if you are here with me, then Eldred is alone with the king?"
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr "Prince Eldred? What are you doing here?"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr "There he is! Get him!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr "Huh? Wha—"
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr "Revelry, Revisited"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr "Deoran’s Company"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr "Sir Grey"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr "Sir Johan"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr "Sir Gwido"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr "So."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr "Guess yer th’ boss now."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr "It would seem as such. Would that Delfador had stayed."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr "Sir, Delfador and the Royal Cavalry are out of sight."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr "All healed up? Excellent. We’ll soon put this rebellion to rest."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr "(shocked) You—"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr "<span size='x-small'>Finally.</span>"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr "No!"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr "<span size='x-small'>You all saw tha—</span>"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr "(gulp, deep breath)"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr "You all saw that! DEORAN HAS SLAIN THE KING!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr "What!? I—"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr "You—"
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr "I—"
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr "Avenge the king! Don’t let them escape!"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr "$gold_pickup gold"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr "When an enemy leader is defeated, their remaining soldiers will flee."
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr "This is the second-to-last scenario."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr "I hear orc-drums approaching the eastern road! Our time runs short."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr "You will now start the next scenario with $bonus_gold total gold!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+"So much ill will... The captains of old would have died for their king."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr "...witch?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr "I— yes, of course! Anything I can do."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr "Survive as long as possible (bonus gold next scenario)."
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr "My thoughts must now turn to flight: make haste, my loyal steed!"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr "(grins)"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr "Prince Eldred, I lay down my arms and accept your offer of surrender."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr "Idiot."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr "The traitor is vanquished! Now hail, hail to your new king!"
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr "Hail King Eldred!"
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr "Hail, long live King Eldred!"
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr "Long live the king!"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr "Yes. Long live the king."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr "The King is Dead"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr "Gods... what a fool I have been."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr "But, I—"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr "Thank you."
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr "Then, we fight?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr "Then, we fight!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr "Long Live the Queen"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr "Delfador’s Rebels"
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr "King Eldred"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr "Wesnoth Auxiliaries"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr "No! Methor... Don’t die!"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr "Look sharp, I think they’ve spotted us!"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr "Defeat Eldred"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr "NO!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr "Eldred"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr "...you can?"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr "magical"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr "I am Delfador."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr "And you are dust."
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr "After all, the civil war has only just begun..."
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr "Arcane Enforcer"
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr "female^Arcane Enforcer"
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr "Rogue Mage"
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr "female^Rogue Mage"
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr "Shadow Mage"
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr "chill"
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr "female^Shadow Mage"
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr "Cave Entrance"
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr "Prince of Wesnoth"
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr "broadsword"
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr "Queen"
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr "Mage"
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr "staff"
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr "Red Mage"
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr "Arch Mage"
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr "Great Mage"
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr "Ambassador"
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr "trample"
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr "Veteran Commander"
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr "lance"
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr "Cavalier"
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr "Crown Prince"
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr "baneblade"
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr "shadow wave"
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr "sword"
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr "javelin"
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr "King of Wesnoth"
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr "longsword"
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr "Giant Crab"
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr "spit"
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr "Eyestalk"
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr "gaze"
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr "Silverback"
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr "fist"
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr "Orcish Adept"
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr "siphon"
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr "Orcish Shaman"
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr "Orcish Sorceress"
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr "sap"
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr "Beacon"
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr "Saurian Devotee"
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr "curse"
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr "Saurian Juvenile"
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr "Saurian Spike"
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr "spear"
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr "throwing spear"
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr "Kraa!"
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr "Glob glob glob."
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr "Fsss crackle hiss."
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr "missile"
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr "<span color='#ff0000' size='x-small'>No Target</span>"
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr "Next turn, this unit dies."
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr "panacea"
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr "summoner"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr "chill touch"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr "Familiar"
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr "mnemonic"
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr "<span color='#DD6F6F'>counterspelled</span>"
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr "Counterspell is nullifying this magical attack."
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr "consume"
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr "dancing daggers"
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr "Taste drakefire!"
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr "I’ve got you! You can thank my old master for inventing this spell."
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr "Well somebody had to! And you’re welcome!"
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr "lightning"
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr "chain"
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr "Dear lords of light, what was that?!"
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr "Cast Spells"
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr "<span color='#a308b8' size='small'>Max XP!</span>"
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr "Methor"
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr "Arand"
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr "Asheviere"
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr "Lionel"
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr "Lord Maddock"
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr "Colonel Dommel"
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr "Iliah-Malal"
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr "Garard II"
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr "No, it can’t end yet! I have so much left to do..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr "No! Magic, why have you failed me..."
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr "If only I had been a little wiser..."
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr "War, pain, death... I tried so hard to change things..."
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr "I have failed my kingdom and my duty..."
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr "A horse! A horse! My kingdom for a horse..."
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr "It’s finally over..."
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr "Blasted orcs..."
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr "Nobody can cheat death forever..."
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr "Deoran, I never had a chance to tell you—"
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr "Boss, I ’aint feelin’ too hot..."
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr "I ’aint feelin’ too hot..."
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr "I shoulda never left my swamp..."
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."

--- a/po/wesnoth-tdg/eo.po
+++ b/po/wesnoth-tdg/eo.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: eo\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/es.po
+++ b/po/wesnoth-tdg/es.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/es_419.po
+++ b/po/wesnoth-tdg/es_419.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es_419\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/et.po
+++ b/po/wesnoth-tdg/et.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: et\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/eu.po
+++ b/po/wesnoth-tdg/eu.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: eu\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/fi.po
+++ b/po/wesnoth-tdg/fi.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: fi\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/fr.po
+++ b/po/wesnoth-tdg/fr.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/ga.po
+++ b/po/wesnoth-tdg/ga.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ga\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/gd.po
+++ b/po/wesnoth-tdg/gd.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: gd\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/gl.po
+++ b/po/wesnoth-tdg/gl.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: gl\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/grc.po
+++ b/po/wesnoth-tdg/grc.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: grc\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/he.po
+++ b/po/wesnoth-tdg/he.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: he\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/hr.po
+++ b/po/wesnoth-tdg/hr.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/hu.po
+++ b/po/wesnoth-tdg/hu.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: hu\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/id.po
+++ b/po/wesnoth-tdg/id.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: id\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/is.po
+++ b/po/wesnoth-tdg/is.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: is\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/it.po
+++ b/po/wesnoth-tdg/it.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/ja.po
+++ b/po/wesnoth-tdg/ja.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/ko.po
+++ b/po/wesnoth-tdg/ko.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ko\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/la.po
+++ b/po/wesnoth-tdg/la.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: la\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/lt.po
+++ b/po/wesnoth-tdg/lt.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: lt\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/lv.po
+++ b/po/wesnoth-tdg/lv.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: lv\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/mk.po
+++ b/po/wesnoth-tdg/mk.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: mk\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/mr.po
+++ b/po/wesnoth-tdg/mr.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: mr\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/my.po
+++ b/po/wesnoth-tdg/my.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: my\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/nb_NO.po
+++ b/po/wesnoth-tdg/nb_NO.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: nb\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/nl.po
+++ b/po/wesnoth-tdg/nl.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: nl\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/pl.po
+++ b/po/wesnoth-tdg/pl.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: pl\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/pt.po
+++ b/po/wesnoth-tdg/pt.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: pt\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/pt_BR.po
+++ b/po/wesnoth-tdg/pt_BR.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/racv.po
+++ b/po/wesnoth-tdg/racv.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: racv\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/ro.po
+++ b/po/wesnoth-tdg/ro.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/ru.po
+++ b/po/wesnoth-tdg/ru.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ru\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/sk.po
+++ b/po/wesnoth-tdg/sk.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: sk\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/sl.po
+++ b/po/wesnoth-tdg/sl.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/sr.po
+++ b/po/wesnoth-tdg/sr.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: sr\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/sr@ijekavian.po
+++ b/po/wesnoth-tdg/sr@ijekavian.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: sr@ijekavian\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/sr@ijekavianlatin.po
+++ b/po/wesnoth-tdg/sr@ijekavianlatin.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: sr@ijekavianlatin\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/sr@latin.po
+++ b/po/wesnoth-tdg/sr@latin.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: sr@latin\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/sv.po
+++ b/po/wesnoth-tdg/sv.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: sv\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/tl.po
+++ b/po/wesnoth-tdg/tl.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: tl\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/tr.po
+++ b/po/wesnoth-tdg/tr.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: tr\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/uk.po
+++ b/po/wesnoth-tdg/uk.po
@@ -1,0 +1,8405 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: uk\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/vi.po
+++ b/po/wesnoth-tdg/vi.po
@@ -1,0 +1,8404 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: vi\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/wesnoth-tdg.pot
+++ b/po/wesnoth-tdg/wesnoth-tdg.pot
@@ -1,0 +1,8402 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/zh_CN.po
+++ b/po/wesnoth-tdg/zh_CN.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh_CN\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""

--- a/po/wesnoth-tdg/zh_TW.po
+++ b/po/wesnoth-tdg/zh_TW.po
@@ -1,0 +1,8403 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2025-01-21 09:37 UTC\n"
+"PO-Revision-Date: 2025-01-21 09:37 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh_TW\n"
+
+#. [editor_group]: id=the_deceivers_gambit
+#. [campaign]: id=The Deceivers Gambit 1
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:54
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:156
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:18
+msgid "The Deceiver’s Gambit"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "1x enemies, 70% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:66
+msgid "Easy"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "2x enemies, 90% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:67
+msgid "Normal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "4x enemies, 100% xp"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:68
+msgid "Hard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "4x enemies, less gold"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:69
+msgid "Deadly"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:76
+msgid "Campaign Design"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:82
+msgid "Setting and Story"
+msgstr ""
+
+#. [about]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:88
+msgid "Miscellaneous Graphics"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:129
+msgid "<span size='x-small'>Miss</span>"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:157
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:183
+msgid "TDG"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:168
+msgid ""
+"Yearning for adventure, a newly-trained apprentice from the magic academy at "
+"Alduin fights alongside Wesnoth’s king during a major war against the orcs "
+"of the north.\n"
+"\n"
+"Play a pivotal role during this time of turmoil, as despite a string of "
+"battlefield victories Wesnoth seems to be slipping inexorably into chaos...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:172
+msgid "(Intermediate level, 7 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 1
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:173
+msgid ""
+"Story continued in:\n"
+"The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:182
+msgid "The Deceiver’s Gambit II"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:194
+msgid ""
+"As losses continue to mount, Delfador embarks on a dangerous mission behind "
+"enemy lines. The journey will be perilous, but what awaits at its end will "
+"be worse still. What does it truly mean to be a hero?\n"
+"    \n"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:196
+msgid "(Complex campaign, 8 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=The Deceivers Gambit 2
+#: data/campaigns/The_Deceivers_Gambit/_main.cfg:197
+msgid ""
+"Story continued in:\n"
+"“Asheviere’s Dogs”"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Blast the fire elementals in '<i>Graduation</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:21
+msgid "Scenario 0: Sandbagger"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Complete '<i>Stirrings of War</i>' without killing any goblin spearmen."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:22
+msgid "Scenario 1: Goblinitarian"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Complete the hidden victory condition in '<i>Fort Garard</i>'"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:23
+msgid "Scenario 2: Bloodthirsty"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid ""
+"Complete '<i>The Ambassador</i>' without damaging any wose, even in "
+"retaliation."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:24
+msgid "Scenario 3: Mellon"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Drown the silverback in '<i>The Sylvan Seer</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:25
+msgid "Scenario 4: Gurgle gurgle"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Defeat both enemy leaders in '<i>The Deceiver</i>' before Garard does."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:26
+msgid "Scenario 5: Hook, Line, and Sinker"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Complete '<i>Ring of Swords</i>' with Garard at full hp."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:27
+msgid "Scenario 6: Royal Privilege"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Complete '<i>The Great River</i>' in 20 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:28
+msgid "Scenario 7: On the Clock"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid ""
+"Complete '<i>Ruins of Saurgrath</i>' on the same turn you’re first spotted."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:29
+msgid "Scenario 8: Monster in the Mist"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Complete '<i>Omaranth</i>' before turns run out."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:30
+msgid "Scenario 9: Sapper"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Command four ghosts at once in '<i>Houses of the Dead</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:33
+msgid "Scenario 10: Army of the Dead"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Complete '<i>Clan Blackcrest</i>' in 10 turns or less."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:35
+msgid "Scenario 11: Combined Arms"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Destroy all villages in '<i>The Traitor</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:36
+msgid "Scenario 12: Scorched Earth"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Defeat all enemy leaders in '<i>Revelry, Revisited</i>'."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:37
+msgid "Scenario 13: Stand Fast"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid ""
+"Complete the first phase of '<i>Long Live the Queen</i>' without moving "
+"Delfador."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/The_Deceivers_Gambit/achievements.cfg:38
+msgid "Scenario 14: Armchair General"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:48
+msgid "Magic Missile"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:50
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 7x3 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:57
+msgid "Shield"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:59
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>+20% dodge chance</i> until the "
+"start of your next turn or until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:77
+msgid "Panacea"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:79
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to fully heal the lowest-health adjacent "
+"living ally, and increase its\n"
+"           attacks, strikes, and damage by its level. <span "
+"color='#dd0000'><b>Next turn, it dies.</b></span>"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:87
+msgid "Animate Mud"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:89
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit "
+"<i>Mudcrawlers</i>. Mudcrawlers gain +100% damage and XP\n"
+"               while adjacent to you, but dissolve at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:101
+msgid "Chill Touch"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:103
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Melee 6x3 cold, <i>slows</"
+"i>. Replaces your default melee attack."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:110
+msgid "Levitate"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:112
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>8xp</i></span> to gain <i>flight</i> and the "
+"<i>skirmisher</i> ability until the start of your next turn or until "
+"cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:120
+msgid "Find Familiar"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:122
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Begin each scenario with "
+"your trusty pet raven.\n"
+"               Your familiar’s level and xp persist across scenarios, but "
+"reset if it dies."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:129
+msgid "Mnemonic"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:131
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever an adjacent "
+"ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:143
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:209
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:260
+msgid "Fireball"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:145
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:152
+msgid "Siphon"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:154
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 8x4 arcane, "
+"<i>magical</i>, <i>drains</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:161
+msgid "Blizzard"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:163
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to slow enemy units and freeze terrain in a 3-hex radius."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:171
+msgid "Counterspell"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:173
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>16xp</i></span> to <i>disallow magical attacks</i> in a 3-"
+"hex radius, until cancelled.\n"
+"           Prevents spellcasting, but not passive skills."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:181
+msgid "Polymorph"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:183
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Transform into a stoat "
+"(<span color='#00bbe6'><i>1xp</i></span>), bear (<span "
+"color='#00bbe6'><i>8xp</i></span>), crab (<span color='#00bbe6'><i>16xp</i></"
+"span>), or roc (<span color='#00bbe6'><i>32xp</i></span>). Lasts until "
+"cancelled.\n"
+"            Replaces Delfador’s attacks, spells, and passives, but does not "
+"affect hitpoints."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:195
+msgid "Glamour"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:197
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Gain the <i>leadership</"
+"i> ability."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:211
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 12x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:218
+msgid "Dancing Daggers"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:220
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 5x8 blade, "
+"<i>backstab</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:227
+msgid "Enthrall"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:229
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to magically disguise yourself as an awe-inspiring drake,\n"
+"           reducing accuracy and dodge by 10% for enemies in a 2 hex radius. "
+"Lasts until cancelled."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:237
+msgid "Animate Fire"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:239
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Learn to recruit <i>Fire "
+"Guardians</i>. Fire Guardians gain +100% damage and XP\n"
+"               while adjacent to you, but dissipate at the end of each "
+"scenario."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:246
+msgid "Contingency"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:248
+msgid ""
+"<span color='#a9a150'><i><b>Passive:</b></i></span> Whenever one of your "
+"human soldiers dies, they are instead returned safely to your recall list."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:262
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 18x4 fire, "
+"<i>magical</i>."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:269
+msgid "Chain Lightning"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:271
+msgid ""
+"<span color='#ad6a61'><i><b>Attack:</b></i></span> Ranged 14x4 fire, "
+"<i>magical</i>. If this attack kills an enemy, you may attack again."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:278
+msgid "Time Dilation"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:280
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>48xp</i></span> to grant yourself and all allies double "
+"movement and a second attack this turn.\n"
+"           When this turn ends, affected units become slowed."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:288
+msgid "Cataclysm"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:290
+msgid ""
+"<span color='#6ca364'><i><b>Spell:</b></i></span> Spend <span "
+"color='#00bbe6'><i>99xp</i></span> and <span color='#c06a61'><i>your attack</"
+"i></span> to injure everyone in a 5-hex radius for ~75% of their\n"
+"           current HP. Dries water, melts snow, burns forest, and levels "
+"castles/villages."
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Cast Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:357
+msgid "Select Delfador’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Cast the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:358
+msgid "Select the Apprentice’s Spells"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:364
+msgid ""
+"<span size='small'><i>Delfador knows many useful spells, and will learn more "
+"as he levels-up automatically throughout the campaign. Delfador does not use "
+"XP to level-up. Instead,\n"
+"Delfador uses XP to cast certain spells. If you select spells that cost XP, "
+"<b>double- or right-click on Delfador to cast them</b>. You can only cast 1 "
+"spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:365
+msgid ""
+"<span size='small'><i>The apprentice knows several useful spells, and will "
+"learn more as he levels-up automatically throughout the campaign. The "
+"apprentice does not use XP to level-up. Instead,\n"
+"he uses XP to cast certain spells. If you select spells that cost XP,"
+"<b>double- or right-click on the apprentice to cast them</b>. You can only "
+"cast 1 spell per turn.</i></span>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:439
+msgid "Confirm Spells <small><i>(can be changed every scenario)</i></small>"
+msgstr ""
+
+#. [lua]: display_skills_dialog
+#: data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua:442
+msgid "Choose Later"
+msgstr ""
+
+#. [lua]: wesnoth.interface.game_display.unit_status
+#: data/campaigns/The_Deceivers_Gambit/lua/theme.lua:13
+msgid ""
+"dazed: This unit is dazed. It suffers a -10% penalty to both its defense and "
+"chance to hit (except for magical attacks)."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:4
+msgid "Graduation"
+msgstr ""
+
+#. [side]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:124
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:127
+msgid "Apprentice"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:19
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:27
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:57
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:22
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:62
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:36
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:26
+msgid "Isle of Alduin"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:33
+msgid "Summoned Monsters"
+msgstr ""
+
+#. [message]
+#. an informational plaque on a statue of a female arch-mage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:68
+msgid ""
+"<i>In honor of master Heryera, who gave her life in defense of Elensefar "
+"against the lich Ras-Tabahn.</i>"
+msgstr ""
+
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:103
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:163
+msgid "Leollyn"
+msgstr ""
+
+#. [trait]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:106
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:17
+msgid "Zero upkeep."
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:115
+msgid "Saegwylyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:148
+msgid "The Author"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:153
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a frighteningly difficult "
+"challenge even for experienced players! If you’re new to Wesnoth, I strongly "
+"suggest trying a lower difficulty."
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Hard difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:160
+msgid ""
+"NOTE: ‘Hard’ difficulty is intended to be a serious challenge even for "
+"experienced players! If you’re new to Wesnoth, you may want to try a lower "
+"difficulty."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the fire wraiths are not visible yet. Delfador is about to appear on the left edge of the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:169
+msgid "Faster, faster! The wraiths will soon be upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing events that happened minutes before the beginning of the campaign
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:179
+msgid ""
+"Hey, how was I supposed to know the halfway cave was warded! All I did was "
+"throw a few celebratory firebolts! For the spectators, you know?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. there's a blue orb at the east edge of the map, which will dispel the fire guardians that will soon appear to chase Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:184
+msgid "Just hurry and get to the dispel orb!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:192
+msgid "Reach the blue orb at the east edge of the map"
+msgstr ""
+
+#. [objective]: condition=lose
+#. Delfador is currently just named "apprentice". He doesn't get his name until scenario 2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:197
+msgid "Death of the Apprentice"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this tells the player that 1) Delfador is Methor's apprentice, and 2) Delfador is very reckless
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:215
+msgid ""
+"Out of all the masters in Alduin, why did the sages curse me with the most "
+"reckless apprentice in all Wesnoth?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. this line is spoken as soon as the fire guardians enter the map
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:232
+msgid "The wraiths are catching up! Keep moving!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#. another of Delfador's instructors; implying Delfador has attempted to firebolt the fire guardians before, and it ended badly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:237
+msgid "10 copper says he tries to firebolt them again..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Levitate is one of many spells that Delfador will have access to throughout this scenario. It grants him flight and skirmisher, which
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:242
+msgid ""
+"Ignore her. You’re making good time so far — now cast Levitate and slip past "
+"the eyestalks! You may need to cast it several turns in a row to keep ahead "
+"of the wraiths."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:246
+msgid ""
+"<i>Levitate!?</i> Why bother with utility spells when fireballs are so much "
+"better?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:250
+msgid ""
+"Oh for the love of— remember what happened last time you tried to fight? "
+"Just do it!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:255
+msgid "Casting Spells:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:256
+msgid "Double- or right-click on the apprentice to cast spells."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. spoken after Delfador attacks the fire guardians, referencing the "10 copper" bet from earlier. Since there are 3 guardians and they have 50% fire resistance, this is not a wise move by Delfador.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:273
+msgid "All right, all right! It’s just as you said."
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:278
+msgid "10 more copper for me!"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:291
+msgid ""
+"So he does know proper magic after all. It only took four failed exams..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. if the levitate spell ends over impassable terrain (like lava), Delfador dies
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:305
+msgid ""
+"Almost there! Just fly across the chasm and touch the orb — and make sure "
+"your levitate spell doesn’t end over lava!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:319
+msgid "Hello, my adoring fans!"
+msgstr ""
+
+#. [message]: speaker=Mirya
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:323
+msgid "Hey, what’re you doing! This isn’t the normal route!"
+msgstr ""
+
+#. [message]: speaker=Rolyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:327
+msgid "We’d better get out of here. Remember what happened on his last exam?"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:382
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1904
+msgid "<span color='#ffffff' size='x-small'>Contingency</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just reached the end of the obstacle course / final exam (and the end of the scenario0
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:446
+msgid "Look at me, I made it! This time just has to be good enough!"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:451
+msgid "<span size='small'>Well, what do you think?</span>"
+msgstr ""
+
+#. [message]: speaker=Saegwylyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:457
+msgid ""
+"<span size='small'>I say no. A mage needs wisdom; this apprentice cares only "
+"for his own amusement. This one is a petty magician, not a wise sage or "
+"advisor of kings.</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:461
+msgid ""
+"<span size='small'>I say yes. I admit my apprentice enjoys the spotlight "
+"more than most, but with this much magical aptitude who wouldn’t want to "
+"show off?</span>"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:465
+msgid ""
+"<span size='small'>I think it’s obvious this is one of the most gifted magi "
+"we’ve trained in years. The skill is innate; the wisdom will come with time."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:470
+msgid ""
+"<span size='small'>So mine is the deciding vote. Very well, I’ve made up my "
+"mind.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. non sequitur. The screen has faded to black, and Delfador is hearing a voice with no apparent origin. In scenario 4, this is later revealed to be the elvish seer Elende, prophesying about Delfador's future.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:497
+msgid ""
+"<i>The Deceiver weaves the twine encircling the puppets in the court of "
+"royals.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:501
+msgid ""
+"<i>Fatherless prince and sovereignless king, the balance of man hangs upon "
+"this thread.</i>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:505
+msgid ""
+"<i>Should force and fire brandish themselves where wisdom and pity are left "
+"wanting, this string of fate shall inexorably be sundered.</i>"
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#. the screen has faded back to normal, and master Leollyn is annoyed that Delfador wasn't paying attention
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:518
+msgid "Apprentice! Are you listening? I’m trying to congratulate you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:522
+msgid "But who— what— um, yes, I must have drifted off."
+msgstr ""
+
+#. [message]: speaker=Leollyn
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:526
+msgid ""
+"...as I was saying... apprentice, congratulations on your sucessful "
+"completion of the practical portion of your graduation exam! Now we proceed "
+"to the written section; please conjure your quill and parchment..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just taken lethal damage
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:545
+msgid "Oh no! Master, help!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor casts a spell to save Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:550
+msgid "I’ll save you!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg:565
+msgid ""
+"(sigh) Not again! I suppose you’ll have to retry the exam next year... for "
+"the sixth time."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:8
+msgid "Stirrings of War"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:19
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>The Deceiver’s Gambit </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:27
+msgid ""
+"In the year 481 after the founding of Wesnoth, King Garard the Second grew "
+"discontent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:30
+msgid ""
+"With the Estmarks secured and the southern bandits pacified, his empire had "
+"grown large and powerful. Garard’s marriage to the young Asheviere had "
+"secured him a queen, as well as the promise of an heir. Yet despite these "
+"achievements, the restless king could find no peace."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:34
+msgid ""
+"The king’s love lay in sword and shield, in battle and blood. Dissatisfied "
+"with a life of languor among the estates of Weldyn, Garard looked instead to "
+"the orcs of the Heart Mountains, whose raids had long been a nuisance across "
+"his northern border."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:38
+msgid ""
+"Eager to retaliate, the king sent messengers far and wide. He called to arms "
+"an expeditionary force to cross the Great River and lay claim to orcish "
+"lands; a great show of power to secure Wesnoth’s might."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:42
+msgid ""
+"One of these messengers rode to the venerable Academy of Magic on Alduin, "
+"summoning a contingent of magi to support Garard’s endeavor. A particular "
+"young apprentice was especially enthusiastic..."
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:67
+msgid "Ozgob"
+msgstr ""
+
+#. [side]: type=Orcish Grunt
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:70
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:79
+msgid "Clan Whitefang"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:115
+msgid "Weldyn"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "15 gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:136
+msgid "Treasure! Looks like a previous victim of the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:167
+msgid "Are we there yet?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. a "seeker spell" is a made-up word to describe some kind of spell that helps you find your way to a destination
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:172
+msgid ""
+"Nearer than the last time you asked, yet further than we will be the next. "
+"Really apprentice, would it kill you to learn a proper seeker spell?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador, being himself, doesn't care to worry about utility spells like a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:177
+msgid ""
+"Maps don’t win wars! Admit it, you’re at least a little excited... "
+"adventure, bravery, heroism! And as the head of our delegation, you’ll even "
+"get to counsel with the king himself!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:181
+msgid "<i>Quiet!</i> <span size='small'>Do you hear that?</span>"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. 'stragglers' refers to soldiers (like Delfador and Methor) who are joining Garard's war-camp, but are arriving late
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:191
+msgid ""
+"“Kill the stragglers” they says. “You’ll have our best warriors” they says. "
+"N’ all I get are a bunch o’ lousy goblins? Lousy lazy lying—"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:196
+msgid "They’re here, they’re here! Humans on the clan road!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:200
+msgid "—then grab your spear, you loathsome lout! Time to do our jobs!"
+msgstr ""
+
+#. [message]: role=gobbo1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:204
+msgid "No, no, no! No fight! I run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:211
+msgid "Why you runtish, yellow—"
+msgstr ""
+
+#. [message]
+#. multiple goblins are running away
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:218
+msgid "Wait for me!"
+msgstr ""
+
+#. [message]: role=gobbo3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:222
+msgid "Run away across the river!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has just killed one of the fleeing goblins
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:230
+msgid "I said FORM RANKS! Rousers, get these runts organized!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:234
+msgid "Gumpnug"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:249
+msgid "Bork"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:265
+msgid "Mirnik"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:281
+msgid "Gump"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:301
+msgid "Defeat Ozgob"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:305
+msgid "Death of Methor or the Apprentice"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:326
+msgid "Choosing Spells:"
+msgstr ""
+
+#. [object]
+#. Delfador does not yet have a true name; he's only called "apprentice"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:328
+msgid ""
+"Before each scenario in this campaign, you will have the opportunity to "
+"select which spells to equip for the upcoming battle. Remember, double- or "
+"right-click on the apprentice to cast chosen spells!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can only recruit mudcrawlers; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:349
+msgid ""
+"You’re not yet a journeyman, apprentice! Your mudcrawlers are not without "
+"use, but to recruit mages I’ll need to stand on our keep."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor says this when Delfador stands on their keep. Delfador can not recruit; Methor recruits mages
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:356
+msgid ""
+"You’re not yet a journeyman, apprentice! To recruit mages I’ll need to stand "
+"on our keep."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:498
+msgid "New Recruit:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:369
+msgid ""
+"The apprentice is the main character of this campaign, but right now he’s "
+"not your leader. Methor is your leader, and he can recruit mages.\n"
+"\n"
+"Mages are deadly ranged attackers, with accurate <i>magical</i> attacks that "
+"are difficult to dodge. They have few hitpoints and are highly vulnerable in "
+"melee combat, so take good care of them!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:382
+msgid ""
+"<i>Rain is purely visual, and has no impact on gameplay. If rain is "
+"distracting or reduces performance, you can disable it by opening the "
+"Preferences menu (Ctrl-P), selecting “Display”, and unchecking “Animate "
+"Map.”</i>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:433
+msgid "$unit.name’s dead! Run away!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:465
+msgid "Run for your lives!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:466
+msgid "$unit.name’s dead! Run back across the river!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:467
+msgid "Noooo, $unit.name! I don’t want to die too!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:468
+msgid "Run away, $unit.name’s dead!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. said in response to goblins running away from the fight
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:475
+msgid "Cowards!! Fight and die like real orcish warriors!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#. said after any living unit dies (both human and goblin)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:507
+msgid ""
+"(sigh) More casualties of pointless politics. I joined the order to do some "
+"<i><b>good</b></i> in the world..."
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#. Ozgob has lost most of his goblins ('runts'), and is about to charge at Delfador personally
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:529
+msgid ""
+"I’ve had it with this! Never send a runt to do a warrior’s job, I’ll bring "
+"you down myself!"
+msgstr ""
+
+#. [message]
+#. Ozgob has died, and any remaining goblins are deserting him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:575
+msgid "Run away!"
+msgstr ""
+
+#. [message]: speaker=Ozgob
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:580
+msgid "Useless... goblins..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. King Garard has just appeared, along with a few knights
+#. King Garard has just appeared, along with a few knights
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:600
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:638
+msgid ""
+"Ride forth, knights of Wesnoth! No orc who sets foot on our soil shall leave "
+"alive!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard came to kill the goblins, but Delfador has already done it.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:608
+msgid ""
+"But what’s this? It seems some magi have beaten us to battle and already "
+"slain our foe! I wasn’t making a mistake bringing Alduin into the fold after "
+"all. Who commands this detachment?"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:612
+msgid ""
+"(bowing) My Lord, Alduin dispatched these apprentices as response to your "
+"war-call. I volunteered to lead them, and I now place my medicinal arts at "
+"your service."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:616
+msgid ""
+"A healer? Well, at least you’ve brought some proper numbers with you. Follow "
+"me back to camp. We attack on the ’morrow!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Delfador has failed to defeat the goblins. Garard does not respect him.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:646
+msgid ""
+"But what’s this? Some pencil-necked magi have beaten us to battle, yet can’t "
+"even finish off a few goblins! Bah, go back to Alduin, you scholars have no "
+"place in war after all."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/01_Stirrings_of_War.cfg:650
+msgid "Now I’ll never make a name for myself..."
+msgstr ""
+
+#. [scenario]
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:61
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:76
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:90
+msgid "Fort Garard"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:33
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:43
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:225
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:237
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:249
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:159
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:173
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:184
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:80
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:93
+msgid "Whitefang Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:39
+msgid "Khavur"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#. after Delfador kills several goblins, the goblin leader calls the retreat. Remaining goblins fall back to their keep
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:108
+msgid "Too many humans!"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:166
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:48
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:63
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:39
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:38
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:202
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:56
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:239
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:302
+msgid "Army of Wesnoth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:221
+msgid "Ushnug"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:233
+msgid "Gusush"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:245
+msgid "Vidrug"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:329
+msgid ""
+"At last, here we stand on the eve of battle! Remember the plan: Lionel, "
+"soften up the orcish warriors while my knights look for an opening; Methor, "
+"guard the camp in my absence — those goblin raiders are still being a "
+"nuisance."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:333
+msgid ""
+"M’lord, weren’ we waiting for the queen? Your wife had expressed an interest "
+"in seeing an orc."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:337
+msgid ""
+"Bah, the queen will sort herself out. I have waited long enough to join the "
+"field; ere dusk, my lance will be stained with orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:343
+msgid ""
+"He wants us to stay behind and stand guard?! We should finish off those "
+"goblins ourselves!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:347
+msgid ""
+"Oh apprentice, whatever shall I do with you... If you want to lead the "
+"guards against the goblins I won’t stop you, but I’m afraid I can’t help you "
+"either. My place is here, tending to the sick and injured."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:351
+msgid ""
+"It’s just like you to miss out on all the fun! You’ll never win the king’s "
+"praise sitting in your keep; don’t expect me to save you any goblins!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:368
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:462
+msgid "Defeat Khavur, the goblin leader"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:372
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:472
+msgid "Win before Garard defeats the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:376
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:476
+msgid "Garard defeats Vidrug, the orcish leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:380
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:480
+msgid "Death of Delfador or Methor"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:384
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:484
+msgid "Death of Garard or Lionel"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:399
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:476
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:434
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:441
+msgid "New Recruits:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:400
+msgid ""
+"Spearman are excellent all-round frontliners with strong damage and good "
+"durability.\n"
+"\n"
+"Bowmen are weaker at range than mages, but are cheaper, tougher, and less "
+"helpless in melee."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:414
+msgid ""
+"<i>If movement and combat are taking too long, you can enable “accelerated "
+"speed” and “skip AI moves” in the Preferences menu.</i>"
+msgstr ""
+
+#. [message]: type=Goblin Spearman
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:425
+msgid "Sun so bright! Wwwait for dark."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard's forces have just killed an orc
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:438
+msgid ""
+"They fall before me! No more politics, no more intrigue; all is finally "
+"right with the world."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. the player is attacking orcs instead of working towards the main scenario objective. This unlocks an alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:453
+msgid ""
+"Apprentice, what are you doing! The king commanded us to engage the goblin "
+"raiders, not the main orcish army!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:457
+msgid ""
+"Lighten up! What’s the worst that could happen? If I slay enough orcs in the "
+"main battle, I’m sure the king won’t mind that I abandoned my post! ...right?"
+msgstr ""
+
+#. [objective]: condition=win
+#. $initial_orcs_remaining is between 8-15, $orcs_remaining is between 0-15
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:468
+msgid ""
+"Defeat at least $initial_orcs_remaining orcs ($orcs_remaining remaining)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. a goblin has just attacked one of Garard's horsemen. Garard previously told Methor to guard against the goblins, but Delfador led the guards to battle instead
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:501
+msgid ""
+"What the— who let all these runts in here! I should have known that healer "
+"would be too soft-hearted to deal properly with the goblins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador (or one of his troops) has killed another orc, and completed his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:528
+msgid "Yes! We got another one!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:533
+msgid "I’ve defeated so many orcs; surely the king must be impressed by now!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:538
+msgid "Bah, filthy humans! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Khavur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:554
+msgid "Nooo! Help meeee..."
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:560
+msgid "Bah, useless runts! This is hopeless. Whitefangs, retreat!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:573
+msgid ""
+"Oh, what’s this? Seems I’m not the only one with a lust for orcish blood!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:577
+msgid ""
+"A proper war-mage is far too valuable to waste on the front lines; I may "
+"have a special assignment for you. What’s your name, boy?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said by Delfador to himself (or maybe just thought in his mind)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:582
+msgid ""
+"<i>(Commendation from the king himself! Now this is what I’ve been waiting "
+"for; finally a chance to prove myself!)</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is realy excited to go with the king, but deeply respects Methor and doesn't want to dissapoint him
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:587
+msgid ""
+"I’d be honored, my lord! But I can’t give you my name — I’m just an "
+"apprentice; Alduin has not yet assigned me one. And... I suppose I shouldn’t "
+"want to leave without my master’s blessing..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:591
+msgid ""
+"By the traditions of our order, no apprentice shall venture alone; that "
+"privilege is first awarded only to the journeymen!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:595
+msgid ""
+"...but apprentice, truth be told, you’ve had a journeyman’s skill for quite "
+"some time now. I was hoping to impart a little more wisdom before advancing "
+"you, but now I understand that fate has other plans."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. nonsense words, sounding magical, copied from the original DM
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:628
+msgid "Thorum restro targa thorum..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. referencing the "Provost of the Council of Archmagi" mentioned by Delfador in HttT
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:648
+msgid ""
+"The light waxes bright. By the power of the high provost and the blessing of "
+"the five sages, I declare you to be nameless NO LONGER!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:653
+msgid "<i><b>DELFADOR</b></i> you shall be, and Delfador shall be YOU."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:661
+msgid ""
+"Delfador, open your eyes. And OPEN THEM AGAIN!\n"
+"\n"
+"I grieve for the apprentice I have lost, but I celebrate the journeyman "
+"Wesnoth has gained. Your naming ceremony is complete."
+msgstr ""
+
+#. [unit]
+#. [event]
+#. [side]
+#. [unit]: type={TYPE}
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:680
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1556
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1648
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1676
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:302
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:20
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:955
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1314
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:13
+msgid "Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:689
+msgid "Del-fa-dor; Delfador! Thanks master, I like the sound of that."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:693
+msgid ""
+"Now farewell, Delfador, my ambitious young friend. If this is what you truly "
+"want, I would never stand in your way. May we meet again in more peaceful "
+"times."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:697
+msgid ""
+"Yes, yes, well done to you both. Now that that’s settled, “Delfador”, it’s "
+"time to pack your bags. You have a long journey ahead of you!"
+msgstr ""
+
+#. [message]: speaker=Vidrug
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:722
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:758
+msgid "Bah... my kin will avenge me..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:728
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:764
+msgid ""
+"The first line of orcs is broken! Continue forth, riders; we ride to victory!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:733
+msgid ""
+"No; that’s not fair! I helped fight the orcs too; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:737
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:773
+msgid "Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:742
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:792
+msgid "He’s going on without us! Now I’ll never impress the king..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has killed the orcish leader, but not killed enough orcs to impress Garard and complete his alternate objective
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:769
+msgid ""
+"No; that’s not fair! I struck the finishing blow; why is he going on without "
+"me?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/02_Fort_Garard.cfg:788
+msgid ""
+"The first line of orcs will soon be broken! Continue forth, riders; we ride "
+"to victory!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:4
+msgid "The Ambassador"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:33
+msgid "Wild Beasts"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:47
+msgid "Woses"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:59
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:73
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:78
+msgid "Lintanir"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:118
+msgid ""
+"When the king said he had a special mission for me, I was hoping for "
+"something a little more exciting than messenger duty... But hey, at least "
+"I‘ve had the time to learn some better spells."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:122
+msgid ""
+"And really, how long can it take to find one measly ambassador? He must be "
+"around here somewhere."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:131
+msgid "Meet Wesnoth‘s ambassador"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:135
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:412
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:908
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:350
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:541
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:611
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:178
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:662
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1013
+msgid "Death of Delfador"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:186
+msgid "This hollow tree is full of bats!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. some woses have just darted between the trees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:232
+msgid "What the— did that tree just move?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:240
+msgid ""
+"The forest is attacking! Quick, grab torches and axes! I wish Methor was "
+"here to see this..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:257
+msgid ""
+"Halt!! Who are you, and why do you trouble the trees of the Grey Grove? "
+"Speak, stranger, or leave this place, lest the wrath of Wesnoth and the "
+"Lintanir elves fall upon you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:261
+msgid ""
+"Hey, it‘s you! You‘re the man I was sent to meet: Ambassador Deoran! The "
+"king gave me a sealed message for you and the north-elves."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:266
+msgid ""
+"You‘re a courier from Wesnoth? My apologies for the harsh words; long has it "
+"been since Weldyn sent to this lonely post."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:270
+msgid ""
+"Yet my apologies will not avail you against the woses — the tree-creatures — "
+"inhabiting this grove. The elves know them to be ancient and powerful; "
+"amongst the forest they are indistinguishable from ordinary oaks, and they "
+"do not look kindly upon us stone-walkers. I have no means of speaking with "
+"them."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:274
+msgid ""
+"I‘m not afraid of a few walking willows; my fire magic will burn a path "
+"through! I‘ve been practicing fireballs for just such an occasion."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:278
+msgid ""
+"Quench your fire and stow your axes! I am a man of the crown, but the good "
+"elves of this place are not. If you wish to gain their favor and deliver "
+"your message, you would be wise not to burn their allies."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:282
+msgid ""
+"Should you truly come as a friend, then we must show the woses such by "
+"traveling through the grove and leaving them unharmed. Only then will you "
+"gain their trust."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:295
+msgid "Move Delfador to the north edge of the forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:299
+msgid "Do not kill any woses"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:303
+msgid "Death of any wose"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:307
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:357
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:825
+msgid "Death of Delfador or Deoran"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:315
+msgid ""
+"Many woses lurk invisibly in the forest. Woses do not move in this scenario, "
+"but will attack if you are adjacent."
+msgstr ""
+
+#. [message]: id=$unit.id
+#. said the first time a unit gets ambushed by a wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:359
+msgid "Ack! It‘s one of them!"
+msgstr ""
+
+#. [message]
+#. second line is mostly a reminder about how level-0 units work
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:364
+msgid ""
+"Woses have the <i>ambush</i> ability, making them invisible while in forest. "
+"Any unit can temporarily reveal a wose by moving adjacent to it, but the "
+"revealer will not be able to move afterwards.\n"
+"\n"
+"Movement is lost even when revealing level 0 Wose Saplings, who normally "
+"(like all level 0 units) do not restrict movement."
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:422
+msgid "<span size='x-small'>Hoom. Oom-shoosh-ola-hum-rum-tum...</span>"
+msgstr ""
+
+#. [event]
+#. peaceful gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:424
+msgid ""
+"<span size='x-small'>Ruma-ula-ola-ilsa-burum-urum. Tula-rulsa-oom-hoom-hoom."
+"</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:433
+msgid ""
+"The woses accept your peaceful intent, and will suffer your delegation to "
+"pass unharmed! Well done; rare is the man who claims the friendship of a "
+"wose-grove."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:437
+msgid ""
+"Already an accomplishment! But only thanks to your help, ambassador. Now "
+"onwards to deliver the king‘s message."
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:456
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:479
+msgid ""
+"<span size='x-small'>Burarum! A-rumgur-gurmum-un-rumba-ala-burarum! Burarum-"
+"ala-bortum-untum! A-rumgur-gurmum-un-rumba-ala-boruroom!</span>"
+msgstr ""
+
+#. [event]
+#. angry gibberish, spoken by a random wose
+#. angry gibberish, spoken by a random wose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:458
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:481
+msgid ""
+"<span size='x-small'>Boom-toom-hun-rum-tum-ala-lola-ala! Burarum! Boruroom!</"
+"span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:463
+msgid ""
+"Oh no, I shouldn‘t have done that! Even if I get through the forest, the "
+"elves will never trust me now..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg:488
+msgid ""
+"You have tarried too long! The woses will no longer tolerate your presence; "
+"leave your message with me and return to Wesnoth!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:42
+msgid "The Sylvan Seer"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:46
+msgid "Dusk"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:104
+msgid "Eloreis"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:116
+msgid "Parandra"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:126
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1211
+msgid "Kalenz"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1227
+msgid "Chantal"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is trying to speak, but gets interrupted by an elvish marshal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:201
+msgid "Ok, yes, but—"
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#. Delfador has brought a message from King Garard to the elves, asking them to attack the whitefang orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:206
+msgid ""
+"I understand Weldyn’s stance on orcs, but Garard cannot change the facts: "
+"our rangers have neither the training nor the elfpower to fight an offensive "
+"war on open ground! What your king asks of us is impossible."
+msgstr ""
+
+#. [message]: speaker=Parandra
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:210
+msgid ""
+"And why would we want to? The orcs stay out of our forests and we stay out "
+"of their hills; this is the way things have been for over a century. Your "
+"king promises us snow-covered mountains and barren desert as spoil, yet what "
+"desire have we for more territory when Lintanir’s broad eaves could support "
+"ten times our numbers?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:214
+msgid ""
+"My honorable lords and ladies, I understand your duty to safeguard your "
+"lands and your people. And is that not what Weldyn does now? King Garard "
+"must know the orcs threaten all peoples of Wesnoth, or why else would he "
+"wage this war?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:218
+msgid "Ah, actually—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:223
+msgid ""
+"You are, of course, welcome to scorn my King’s call; to loiter in Lintanir; "
+"to live and laugh and <i>linger</i>, until Wesnoth’s strength is spent "
+"towards a pyrrhic victory or a bloody defeat.\n"
+"\n"
+"But know that I shall answer my King’s summons; I shall march to war. In "
+"honor of the friendship we have built over my many years here, I would hope "
+"Lintanir will as well."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:238
+msgid "Truly, a moving speech..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:242
+msgid ""
+"Deoran, I am sorry, but Eloreis is right. This is not our fight. I have long-"
+"before seen the horrors of a war between elves and orcs, and have no desire "
+"to plunge my people back into such a nightmare."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:246
+msgid ""
+"Should orcish hordes once again threaten the whole continent like they did "
+"in times past, I would be the first to step up and offer my sword in service "
+"of an alliance.\n"
+"\n"
+"But for territorial gain? I value your friendship and would honor the time "
+"you have spent here, but if Wesnoth goes to war we cannot march alongside "
+"you."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. 'Great-Grandfather' means Kalenz. Chantal is Kalenz's granddaughter
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:253
+msgid ""
+"Great-Grandfather, how can you say such things! Deoran is risking— these "
+"humans are risking their lives in battle, and in all the vastness of "
+"Lintanir we can find naught to offer but kind words? Surely there is "
+"<i>something</i> we can do? Force-of-arms is not the only strength of the "
+"elves."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:257
+msgid ""
+"Chantal, sometimes you remind me so much of your grandmother... perhaps you "
+"are right. I have seen too many friends fall during my unnaturally long "
+"life; sometimes to battle, sometimes to age. I would postpone that fate for "
+"Deoran if I can, for both your sakes."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:261
+msgid ""
+"Deoran, Delfador, what I now speak to you concerns one of our great secrets; "
+"you are not to speak of this to anyone, even to your king."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:266
+msgid ""
+"Deep within Lintanir resides our sylph — an elven seer. We both favor and "
+"fear Elende’s fractured, arcane sight; her strands of reflected prophecy. "
+"Perhaps her visions may illuminate some measure of your futures, and in "
+"doing so help you blaze brighter ones."
+msgstr ""
+
+#. [message]: speaker=Eloreis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:270
+msgid ""
+"Kalenz, are you sure this is wise? Seers are known to be... esoteric... and "
+"Elende has been particularly cloistered these last few decades."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:274
+msgid ""
+"Of course it’s wise! I will accompany them! I wish to spend some time with De"
+"— with these humans before they depart."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:278
+msgid "And so do and so shall I. Come, follow me."
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:297
+msgid "Midnight"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:307
+msgid ""
+"There’s 5 gold pieces in this old boat! I suppose it’s better than nothing."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. said after a Forest Lion, Horned Scarab, or Silverback (a gorilla) attacks one of the player's units
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:353
+msgid "Look out! There’re beasts in the forest!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. said after the player double-clicks on Delfador to try and cast a spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:368
+msgid ""
+"No magic more unusual than a fireball, Delfador. We don’t want to appear "
+"threatening."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:387
+msgid ""
+"Kalenz leads Delfador, Deoran, and Chantal down a labyrinthian path through "
+"the deep wood, past twists and turns and over winding tracks.\n"
+"\n"
+"In many places there is no path at all, and Delfador senses they are guided "
+"more by the elves’ connection to the faerie than by conventional pathfinding."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:393
+msgid ""
+"The sun sets like a dying ember quenched beneath the horizon, and the forest "
+"grows dim. Several times even Kalenz becomes lost, but each time manages to "
+"find the way again. At last, in the dead of night, a small structure looms "
+"out of the forest..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:402
+msgid ""
+"We have arrived. The seer’s mirror pool is just ahead; she herself should be "
+"close by."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:410
+msgid "Find the Sylph"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:414
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:446
+msgid "Death of Delfador, Deoran, Chantal, or Kalenz"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:421
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:453
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1307
+msgid "Kalenz and Chantal will not follow you to the next scenario."
+msgstr ""
+
+#. [message]
+#. there is a pool of water in the middle of the map. Right now the pool is mostly dry - your objective is to solve a puzzle to fill the pool with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:437
+msgid "There lies the mirror pool, but it is strangely dry..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:442
+msgid "Fill the central pool with water"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:479
+msgid ""
+"This is a puzzle segment, and is mostly unaffected by difficulty settings. "
+"If you don’t like puzzles or find it too challenging, you can choose to skip "
+"it."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:481
+msgid "Play the puzzle <i>(includes XP)</i>"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:484
+msgid "Skip the puzzle"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. referencing the events in The South Guard; exaggerated
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:524
+msgid ""
+"Deoran, I took an exam on you during my second year at Alduin. Is it true "
+"you single-handedly beat down a horde of black-magic bandits and saved the "
+"south from destruction? You’re practically a folk hero!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. this is what has happened to Deoran since ending The South Guard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:529
+msgid ""
+"To some, perhaps. The king was less pleased — Garard is magnanimous towards "
+"his favorites, but has little tolerance for failure. I found scant room for "
+"advancement within Wesnoth after so much blood spilled in Westin."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:533
+msgid ""
+"But that all happened many years ago. Ambassador to Lintanir is a "
+"prestigious position, in name if nothing else, and an opportunity to "
+"exercise what I learned from my time amongst the Aethenwood elves. I have "
+"come to value my friends here."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:537
+msgid ""
+"I must confess I look forward to once-again marching in company with others "
+"of my own ilk, yet still I hope to return to Lintanir once my war-duty is "
+"done."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:558
+msgid ""
+"Chantal, we have much to speak about. It is clear you have feelings for the "
+"ambassador. Deoran is no fool; if he does not already know, he certainly "
+"suspects."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:562
+msgid ""
+"—who? What? Great-Grandfather, I have no idea what you’re talking about."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#. continuing the "Chantal has feelings for Deoran" conversation, a moment after it ended
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:569
+msgid ""
+"Okay-fine, yes, but Deoran is a good man! Wise and kind, and quietly bearing "
+"his burden of exile, so far away from his people? And he’s <i>human</i>! "
+"Even a crusty old elf like you has to admit that round ears and stubble are "
+"exotic."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:573
+msgid ""
+"The lives of men burn brightly, but briefly. Even if he returns to Lintanir, "
+"what future could you build together? I will not stop you if you want to "
+"pursue this, but I know all-too-well the pain from outliving those you love. "
+"Cleodil was just as stubborn as you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has just moved a unit onto one of several blue orbs scattered around the map, which has caused a river to change direction. This is part of the puzzle
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:586
+msgid "Look, the stream is changing direction!"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:590
+msgid "Moonstones! Elende, what have you been up to..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:598
+msgid "Odd, the water appears shallow but the beast has vanished entirely."
+msgstr ""
+
+#. [message]
+#. a player unit has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:637
+msgid ""
+"This sandbed is shallow, but the water is suddenly deep and a strange magic "
+"tugs at my legs! I am drowning!"
+msgstr ""
+
+#. [message]
+#. a monster has just drowned in the river, as a result of the player redirecting the river into the beast's hex
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:647
+msgid "<i>Gurgle gurgle gurgle...</i>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has completed their puzzle, and filled the central "mirror pool" with water
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1034
+msgid "There! The pool is full!"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1060
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:890
+msgid "Void"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1101
+msgid "What was that?!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1109
+msgid ""
+"I think this whole mirror world is starting to fall apart! I have to hurry!"
+msgstr ""
+
+#. [message]
+#. the player's units have just been transported into a strange realm, and aren't sure what's going on. Kalenz probably knows more than anybody else, and is calling out to see where Elende is (and what exactly she's doing)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1195
+msgid "Elende!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1200
+msgid "Elende, I come with friends, seeking foresight! Deoran and Del-"
+msgstr ""
+
+#. [message]
+#. immediately after this, magically created "mirror image" units of younger/older versions of Kalenz, Chantal, and Deoran appear
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1205
+msgid ""
+"I know who you are, Delfador of Alduin. But how well do you know yourselves?"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1248
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:58
+msgid "Deoran"
+msgstr ""
+
+#. [message]
+#. referencing the mirror image of Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1264
+msgid "Deoran, is that... you? You look so much younger."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1268
+msgid "What’s going on?! Kalenz, is this normal?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1294
+msgid "Defeat all enemies"
+msgstr ""
+
+#. [objective]: condition=lose
+#. if reduced to 0 hp, Delfador doesn't die. Instead, he's kicked out of the mirror world, and fails the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1299
+msgid "Loss of Delfador"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1310
+msgid ""
+"In this strange world, fate guides every strike. <i>(attacks never miss)</i>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1337
+msgid ""
+"The mortal world beckons; tell me the rest of the prophecy when next we meet!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1338
+msgid "Elende, I hope you know what you’re doing. Good luck, the rest of you!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1339
+msgid ""
+"Owww! Elende, it’s very rude to banish someone without their permission!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just been reduced to 0hp, and been "kicked out" of Elenede's "mirror realm" or wherever she was giving the prophecy
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1347
+msgid "Hey, stop—"
+msgstr ""
+
+#. [time]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1364
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1819
+msgid "Dawn"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has missed the ending of the prophecy, and the player loses the scenario
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1388
+msgid "I didn’t get to finish hearing everything..."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Kalenz's mirror image), referencing Legend of Wesmere's invisibility potion and Landar
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1415
+msgid ""
+"Lich’s eye and brother’s bone; what have you sacrificed to save your people, "
+"Kalenz? Your greatest fear stands before you... ahead of you?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1419
+msgid "That was long ago, Elende! This is about the humans’ story, not mine."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Deoran's mirror image), referencing his exile. I intend "nation" more in the "people" sense than the "country" sense.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1447
+msgid ""
+"Deoran the exile returns home; returns to a nation that scorned him, ignored "
+"his counsel and cast him away. What will become of the life he has built "
+"amongst Lintanir’s twilight eaves?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1451
+msgid ""
+"I know my duty! A captain of Wesnoth will never entertain doubts of loyalty, "
+"whether to his country or his King."
+msgstr ""
+
+#. [message]
+#. spoken by Elende (through Chantal's mirror image), referencing Cleodil's historic death and foreshadowing Deoran's upcoming death
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1461
+msgid "Chantal—"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1465
+msgid ""
+"I already know what you’re going to say Elende! Don’t you dare; I will when "
+"I’m ready."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1469
+msgid ""
+"Then you may soon understand some measure of your great-grandfather’s bygone "
+"sorrows..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1548
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1773
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1779
+msgid "Elende"
+msgstr ""
+
+#. [message]
+#. Elende reaveals that she's the one who gave the weird prophecy thing to Delfador at Alduin, even though she wasn't physically there
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1550
+msgid ""
+"And what of the fire mage? Young but ambitious, brilliant yet foolish. It "
+"has been many moons since I spoke to you at Alduin."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1554
+msgid ""
+"That was you, back at graduation? I knew I heard a voice! Master Leollyn "
+"thought I was going crazy..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1557
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1678
+msgid ""
+"Spend 8 mana to gain flight and the skirmisher ability until the start of "
+"your next turn or until cancelled."
+msgstr ""
+
+#. [message]
+#. pale spy meaning Asheviere. Referencing Asheviere resolving to kill Garard, and working with orcs to arrange the events of the next two scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1585
+msgid ""
+"I see secrets in the dark; a pale spy slips their bonds. A death, a "
+"deceiver. Ringed swords, cold blood, false friends."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's adventures in scenarios 8-10, where he works with (or kills) poachers to fight saurians, then fights undead and a ghost given the appearance of a living drake.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1644
+msgid ""
+"The dark swamp looms. Purses and poachers, mirror and smoke. A figure of "
+"shadow cloaked in the spirits of the dead. Battles won while wars are lost."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1649
+msgid ""
+"Spend 16 mana to disallow magical attacks in a 3-hex radius, until cancelled."
+msgstr ""
+
+#. [message]
+#. referencing the civil war when Asheviere takes power
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1672
+msgid ""
+"Brother against brother, father against child. From the barren throne will "
+"rise an angel of ashes; both great and terrible alike. The delicate balance "
+"of mankind will be broken, and flames shall blaze anew across the embers of "
+"Haldric’s people."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1677
+msgid ""
+"Spend 48 mana to grant yourself and all allies double movement and a second "
+"attack this turn. When this turn ends, affected units become slowed."
+msgstr ""
+
+#. [message]
+#. referncing the future events of HttT; Konrad and Li'Sar retriving the sceptre of fire
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1766
+msgid ""
+"Black soot rains over Weldyn. The line of kings sundered; the ruby of the "
+"wesfolk restored. The nameless son and the ashen daughter."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1775
+msgid ""
+"But this fate is not the only path. Mage of Alduin, you stand at a knot in "
+"the strands, a nexus of the shards. For one brief moment, you will possess "
+"the power to alter the currents of time; to rewrite the future that is "
+"written."
+msgstr ""
+
+#. [message]
+#. referencing Delfador's choice in S10x. He can either listen to a drunk Garard and kill Garard's brother Arand based on false reports of a betrayal, or refuse, stay with Garard, and find out more about Arand before attacking
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1781
+msgid ""
+"When that moment comes, remember... endeavor to bestow not destruction with "
+"that fire that you possess, but the gleaming light of truth instead. Quench "
+"the flames of fear before all your world is consumed."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1785
+msgid "But, what? I don’t understa—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador previously said "But, what? I don’t understa—", but has now been kicked out of Elende's 'mirror world' and is back in the normal world. The scenario is over.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/04_The_Sylvan_Seer.cfg:1841
+msgid "—nd what you’re saying..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:10
+msgid "The Deceiver"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:19
+msgid ""
+"Delfador and his companions departed the mirror grove in hushed silence. The "
+"sylph’s words weighed heavily on each of their minds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:22
+msgid ""
+"After lengthy deliberation, and much to Chantal’s displeasure, Delfador and "
+"Deoran resolved to continue on with their mission. Exiting the forest after "
+"several days’ westward travel, they soon sighted the banners of the king’s "
+"army."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:155
+msgid "Shogro"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:169
+msgid "Khovak"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "These orcs were sitting on some gold! We can put it to better use."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:238
+msgid "{ON_DIFFICULTY4 115 115 115 85} gold"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:136
+msgid "Captain Kestrel"
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:301
+msgid ""
+"Deoran, are you sure you won’t reconsider staying in the Lintanir? What "
+"Elende said..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:305
+msgid ""
+"My duty comes first, always. Would you truly want me any other way, Chantal?"
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#. referencing the beginning of HttT, where Delfador and Konrad are staying with the elves
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:311
+msgid ""
+"Deoran, it has been a pleasure to have you with us these years. And "
+"Delfador, I hope to someday say the same of you as well. Elende seems to "
+"think highly of you, and that means a great deal to me and my people.\n"
+"\n"
+"Should either of you ever find yourselves searching for a home away from "
+"Wesnoth, you will always be welcome with us."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard is attacking what he believes to be the last of the Whitefang Clan orcs. He wonders whether the elves will help him fight or not
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:328
+msgid ""
+"Ah, the fledgeling war-mage returns at last! Welcome, welcome; you’re just "
+"in time to help wipe out the last of this pesky Whitefang clan! Now tell me, "
+"are the north-elves with us?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:332
+msgid "Deepest apologies my Lord, but they are not. Lintanir—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:336
+msgid ""
+"You!? ...no, I suppose war makes equals of us all. I would be remiss to turn "
+"away an able hand, especially without the support of the elves. Just get "
+"ready to fight, ambassador."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:341
+msgid ""
+"As for you, battlemage, your timing couldn’t have been better. The Whitefang "
+"chieftain has holed up in this orcish hill fort, coward that he is. General "
+"Lionel and my brother Arand will press them from the front, while you sneak "
+"in the back and roast him like a pig on a spit."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:345
+msgid ""
+"Without their chief the Whitefangs will dissolve into an infighting mass of "
+"petty squabbles, and our— Wesnoth’s victory will be complete!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:353
+msgid "Defeat Khovak, the orcish warlord"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:361
+msgid "Death of Garard, Arand, Lionel, or Methor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:369
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:464
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:195
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:609
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1082
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1117
+msgid ""
+"Amidst the craggy mountains, daylight is scarce. <i>(shorter days / longer "
+"nights)</i>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:384
+msgid ""
+"Don’t rush the assault, Lionel — no need to waste good men. Take some time "
+"to stage our forces outside their walls, then attack just before dawn on the "
+"third day."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:388
+msgid ""
+"We have them right where we want them. Once our forces are assembled, I "
+"shall join the battle personally and savor this victory up close."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:395
+msgid ""
+"Looks like an easy fight! There’s the fort; there’s the chief. Time to make "
+"the king proud — let’s burn them to cinders."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:399
+msgid ""
+"Perhaps. I’m surprised the Whitefangs have been driven to the brink of "
+"defeat so quickly. Chantal speaks of them as numerous and cunning... I "
+"wonder if something is amiss."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:410
+msgid ""
+"You’re achieving something great here today, m’lord. An orcish clan, broken "
+"upon our spears. Our first foot’old of civilization north of the Great "
+"River. And a fertile new province for Prince Arand to rule!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:414
+msgid ""
+"Far be it from me to look a gift horse in the mouth, Garard, but we’ve "
+"really sacrificed a great deal of political capital for this war. Fields lie "
+"fallow while young blood stains the north. I wish—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:418
+msgid ""
+"Ah, brother, your spies are always whispering one thing or another. First "
+"it’s that whole business with Westin, now it’s too much war! I’m grateful "
+"for you, but I’ll never understand how you put up with all of Weldyn’s "
+"politics and intrigue."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:422
+msgid ""
+"Sometimes the world is simple if you just let it be so.\n"
+"\n"
+"I believe in the simple greatness of Wesnoth. I believe in the brilliant "
+"glory of my forefathers, fighting bloody battle to carve out a place for "
+"mankind amidst this harsh world. And I believe that today, we ourselves, "
+"too, shall become great!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:436
+msgid ""
+"This lake must supply the orcs with water. Maybe I should’ve paid more "
+"attention when master Leollyn was teaching about poison spells..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador muses about poisoning the orcs' water supply
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:441
+msgid ""
+"No, even our enemies deserve to die with dignity. That’s what Methor always "
+"taught."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:453
+msgid ""
+"An orcish shaman! On occasion I’ve known some of the other clans to use "
+"their apprentices as warriors, but Clan Whitefang usually keeps theirs far "
+"from the frontline."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:457
+msgid ""
+"What unusual magic! Some kind of rituals? That looked nothing like what they "
+"teach at the academy."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:461
+msgid ""
+"I don’t think I can tap into whatever fundamental forces she was using, but "
+"now that I have her equipment I’ll bet I could figure out how to imitate "
+"that draining attack.\n"
+"\n"
+"...for our next battle, at least."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:476
+msgid "There’s more of them coming from the north!"
+msgstr ""
+
+#. [message]: speaker=Khovak
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:480
+msgid "Deal with it yourself, worm! I’m sticking to the plan."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:492
+msgid ""
+"You’re squatting in my summer home, trogs! No more raids for you; no more "
+"pillage and plunder. Last chance to surrender!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:496
+msgid "Up yours, pink-skin!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is telling his master Methor about the adventures he had in the last 2 scenarios
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:517
+msgid ""
+"Hello there, master, it’s nice to see you again! You’ll never believe the "
+"adventures I’ve had. Did you know there’s an elvish prophecy about me?!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:521
+msgid ""
+"(smiling) Delfador, don’t make me regret teaching you that psychedelic "
+"spell! I’m just glad you’ve made it back safe and sound."
+msgstr ""
+
+#. [message]: speaker=Shogro
+#. the whitefangs orcs are luring Garard into overextending. Shogro is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:533
+msgid "Stinking Ushka’e! This was a terrible plan..."
+msgstr ""
+
+#. [message]: speaker=Khovak
+#. the whitefangs orcs are luring Garard into overextending. Khovak is bait, and has just died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:558
+msgid "Human dogs! You’ve just sealed your deaths..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:565
+msgid "Run for the hills!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:579
+msgid "Yes! Did I do well, Your Majesty?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:584
+msgid "Indeed you did. Fantastic battle, everyone, the orcs are vanquished!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard thinks he's won, even though he hasn't. "Wold" means "a piece of high, open, uncultivated land or moor."
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:593
+msgid ""
+"Hah! I think “Garard’s Wold” will make a good name for the new province... "
+"or perhaps “Garard’s Triumph”? What do you think, Lionel?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:598
+msgid "Delfador, something’s wrong. This... isn’t the Whitefang chief."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:602
+msgid "What, huh? How can you tell?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:606
+msgid ""
+"I met Clan Whitefang’s leaders around a year ago, when Lintanir negotiated a "
+"treaty. This orc’s face is narrower than I remember, and his helmet doesn’t "
+"have the right war-paint. Delfador, I think we’ve been tricked!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/05_The_Deceiver.cfg:637
+msgid ""
+"Are you even trying to fight, Delfador!? I should have known a mage would "
+"never have the stomach for true battle; get back to Alduin where you belong!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:10
+msgid "Ring of Swords"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:76
+msgid "Ghazgir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:89
+msgid "Muhku"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:106
+msgid "Irbirch"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:110
+msgid "Blackcrest Orcs"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:118
+msgid "Ssisaix"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:122
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:134
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:74
+msgid "Blackcrest Saurians"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:130
+msgid "Xairr"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:296
+msgid "Chief Ushka'e"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. this is the whitefang chief. He's happy that Garard has walked into his trap
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:302
+msgid ""
+"You see? What did I tell you! Their king is nothing but a feeble-minded "
+"goblin runt, who does exactly what I want. The trap is sprung! Now we crush "
+"them."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Irbirch is a representative of clan blackcrest, now (tenuously) allied with whitefang. The "spy" references Asheviere (probably; might be an agent of Iliah-Malal instead), who came up with the plan and told it to the orcs
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:324
+msgid ""
+"Bwahaha, when did you Whitefangs become so weak as to follow the ploy of a "
+"spy? Blackcrest warriors would never have let humans advance so far into our "
+"lands!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. referencing clan blackcrest's saurian allies.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:329
+msgid ""
+"Your “warriors” only survive by cowering behind your slimy lizard allies! "
+"But since Clan Blackcrest has begged so-like trembling goblins, Clan "
+"Whitefang will agree to work together."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. neither side has actually offered to work together. Subversive messengers poised as members of each clan and manipulated them into working together against Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:334
+msgid ""
+"Since WE begged!? YOU invited US here; your messenger was quaking in his "
+"boots when he groveled before Chief Ghuvog asking for help!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:338
+msgid ""
+"What are you talking abo— Oh forget it, just make sure your clan does its "
+"job! No human leaves this valley alive!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:357
+msgid "Bazur"
+msgstr ""
+
+#. [message]: speaker=Bazur
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:365
+msgid "Lousy chief! Lousy plan! Next time I’m doing this on my own terms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. Garard has just realized he's surrounded
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:383
+msgid ""
+"What devilry is this? How did they sneak in behind us. I’m separated from my "
+"generals and most of my soldiers..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:387
+msgid ""
+"Foul orcs, come at me then! If this is where I am to fall, I shall make such "
+"a stand as to stir the gods themselves to tears!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. Asheviere is next to Irbirch. The player is led to think she's been captured, but it's possible she actually went of her own free will to escape Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:397
+msgid ""
+"Nice speech! I wonder what your wife thinks of it? Don’t worry, we’ll have "
+"plenty of fun with her, <b><i>and</i></b> your unborn heir. Haw, haw, haw!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:421
+msgid ""
+"(aghast) That’s— They’ve captured the queen! Asheviere’s no warrior, and "
+"fragile with pregnancy. We have to rescue her!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:425
+msgid ""
+"Surrounded and absent the queen; this is a disaster! Quick, we must rally "
+"what’s left of the crown’s infantry. Send a detachment to rescue queen "
+"Asheviere, and have the rest protect King Garard until Lionel and Arand can "
+"break through to us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:433
+msgid ""
+"(nervous) I’ll never make a name for myself if I get killed! This— this is "
+"really serious. I swear, I won’t let you down."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:441
+msgid "Survive until turns run out"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:445
+msgid "Defeat Irbirch, recapturing queen Asheviere"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:449
+msgid "Fail to rescue Asheviere before turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:457
+msgid "Death of Garard, Asheviere, or Methor"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:477
+msgid ""
+"Heavy Infantrymen are tough-but-slow powerhouses that resist physical "
+"damage.\n"
+"\n"
+"Fencers are fragile but evasive, and posssess the “<i>skirmisher</i>” "
+"ability for slipping unhidered around enemy units."
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#. the player (and Garard) is still alive. The orcs and saurians expected them to die by now
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:538
+msgid "They ssstill sssurvive! Thisss was not the plan!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:542
+msgid ""
+"Then send in more warriors and finish them off, you worthless Blackcrest "
+"lizards! This is <b>our</b> homeland; our ranks swell by the hour, while "
+"these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:547
+msgid ""
+"Useless lizards! Can’t even keep themselves alive, much less win a war. Send "
+"in more orcs! This is <b>our</b> homeland; our ranks swell by the hour, "
+"while these humans dwindle every moment."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:595
+msgid ""
+"This alliance between races is a great ill fortune! I’ve oft known orcs to "
+"recruit trolls, but seldom saurians. And with these three factions fighting "
+"together, soon all the warlords will hear of their prowess."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:599
+msgid ""
+"It takes a great show of strength to unite the fractious orcs, but after "
+"this disaster countless more will surely flock to the Blackcrest and "
+"Whitefang banners. Orcs follow might above all else, even clan blood."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:603
+msgid ""
+"Utter madness, all of this! The orcish clans are a hornet’s nest that should "
+"never have been kicked. Pillagers and raids we can deal with, but total war "
+"is something else entirely."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:607
+msgid "Quiet, both of you! If I wanted your advice I would have asked for it!"
+msgstr ""
+
+#. [message]: speaker=Ushka'e
+#. the player has just attacked the whitefang chief. He then flees
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:619
+msgid "Worthless humans! You’ll never defeat me, or clan Whitefang!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:625
+msgid "Coward! Stand and fight!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:640
+msgid ""
+"They sssneak off to the northeassst, towardsss their queen! Ssshould I "
+"pursssue?"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:644
+msgid "Finish off their king, lizard! I’ll handle things here."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:656
+msgid "Come to ransom back your queen? Too bad, she’s mine!"
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:660
+msgid ""
+"Maybe once she pops out her kid you can pay me double for both! Haw, haw, "
+"haw."
+msgstr ""
+
+#. [message]: speaker=Irbirch
+#. a representative of clan blackcrest has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:672
+msgid ""
+"Great Chief Ghuvog will avenge me! Clan Blackcrest will never rest.. until "
+"Wesnoth is... razed to... ash..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. Asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:685
+msgid "Thank yo—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:690
+msgid "Not now, milady! We have to get you out of here!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#. asheviere tries to say something, but gets interrupted
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:698
+msgid "Garard, I—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:703
+msgid "Now now, woman! I have a battle to fight!"
+msgstr ""
+
+#. [message]: speaker=Ghazgir
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:716
+msgid "I’m not dying! Just... need a moment..."
+msgstr ""
+
+#. [message]: speaker=Mukhu
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:723
+msgid "Nooo! Help meeee!"
+msgstr ""
+
+#. [message]: speaker=Xairr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:730
+msgid "Ssssuch ssssskill!"
+msgstr ""
+
+#. [message]: speaker=Ssisaix
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:737
+msgid "Cursessss, I am sssslain!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel appears with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:785
+msgid ""
+"Rally b’hind me, men! We swore our oaths, now we do our duty. Fight, fight "
+"through to the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. the player has survived, but failed ot rescue the queen
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:804
+msgid ""
+"But the queen! If we leave her in the hands of the orcs she’ll surely be "
+"tortured and killed!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:808
+msgid "I’m sorry, there’s no time! We have to get the king out of here!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:829
+msgid "Sir, look out!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:844
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1428
+msgid "<b><i>NNnrgh!</i></b>"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. Lionel has appeared with reinforcments to help Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:863
+msgid ""
+"You ’aint dyin’ while I draw breath, sir. By the sceptre, I got here just in "
+"time!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:867
+msgid ""
+"They caught us completely by surprise! My forces are holding a corridor but "
+"I don’t know for how long — we’ve got to get you back to Fort Garard."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:871
+msgid ""
+"Lionel, my best general, you’ve saved the day once again! I’d almost feared "
+"this was the end, and it might have been if not for you and young Delfador."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:884
+msgid ""
+"But how did this disaster happen? We were on the eve of victory! Did someone "
+"betray our plans to the enemy? Or am I really just that predictable!?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:888
+msgid ""
+"Couldn’t tell you, m’lord. But I do know that when I became a general I "
+"swore an oath to keep you in one piece, and I don’ intend to break it here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg:892
+msgid "Now c’mon sir, we’re gettin’ you home."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:16
+msgid "The Great River"
+msgstr ""
+
+#. [part]
+#. newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:41
+msgid ""
+"<span font_family='Oldania ADF Std' size='90000'>\n"
+"\n"
+"\n"
+"<i>Part 2 </i></span>"
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:48
+msgid ""
+"The entry of Clan Blackcrest into the war opens up a new front further west, "
+"demanding swift response. Wesnoth fully mobilizes, and a series of bloody "
+"battles at the Ford of Abez end in deadlock for both sides. The ford is "
+"heavily fortified, and river commerce grinds to a halt. Many years pass, "
+"with neither side able to gain an advantage."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:52
+msgid ""
+"Meanwhile, Asheviere gives birth to a healthy baby boy — the Crown Prince "
+"Eldred. Under heavy pressure from both parents and via the tutelage of "
+"General Lionel, Eldred rapidly matures into a princeling soldier. Prince "
+"Arand takes Eldred under his wing, and working in tandem the uncle and "
+"nephew are able to stabilize the eastern front around Fort Garard. Whitefang "
+"orcs still firmly hold the hills, but limited settlement begins."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:56
+msgid ""
+"Delfador grows older, wiser, and significantly more powerful. He makes a "
+"name for himself as the king’s premier war-mage, and quickly gains a "
+"reputation as a ferocious fighter. His bold maneuvers break through orcish "
+"lines several times at the Ford of Abez, but continually become stymied by "
+"saurian reinforcements."
+msgstr ""
+
+#. [part]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:60
+msgid ""
+"As Wesnoth’s casualties continue to mount, and with no end in sight, "
+"Delfador decides to take matters into his own hands. The war-mage prepares a "
+"force of mercenary northmen to sneak behind enemy lines and determine the "
+"nature of Clan Blackcrest’s orc-saurian alliance..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:77
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:30
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:28
+msgid "Delfador’s Hirelings"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:89
+msgid "Ysaxis"
+msgstr ""
+
+#. [side]: type=Saurian Ambusher
+#. [side]
+#. [modify_side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:91
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:99
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:132
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:183
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:521
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:126
+msgid "Clan Blackcrest"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:110
+msgid "Fish (and Beacon)"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:144
+msgid "Mount Oromore"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:323
+msgid "Lynyan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:327
+msgid "Ritharran"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:346
+msgid "Alright men—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. and women
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:351
+msgid "And wom’n!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador is paying these mercenaries himself; they're not wesnoth regulars
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:356
+msgid ""
+"—and women. I’ve selected you because you’re fast, you’re stealthy, and most "
+"importantly: you work for cheap. <span size='x-small'>Lousy Eldred wouldn’t "
+"give me any of my veterans.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. cross the Great River. Not at the Ford of Abez, but near.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:361
+msgid ""
+"This is the perfect time for us to cross! It’s dawn, which means most of the "
+"orcs and saurians will be sleeping, and there’s a heavy winter fog to cover "
+"our movements. We should have time to clear this saurian outpost and sneak "
+"past the frontline before the main orcish army wakes at nightfall."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal brazier on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:366
+msgid ""
+"But first, our objective must be to destroy this outpost’s signal beacon."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. there's a large metal braizer on a mountain filled with wood. If lit, the main orcish army will see it and come to fight Delfadaor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:377
+msgid ""
+"Even through the fog, a beacon fire that large will be visible for miles. If "
+"the orcish host at the Ford of Abez is alerted before we can get through to "
+"the swamp, we’ll be slaughtered!\n"
+"\n"
+" <span size='x-small'>Not that I wouldn’t mind a chance to incinerate more "
+"of those greasy buggers...</span>"
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#. Ritharran is a rogue mage; a half-magi half-bandit. "Hey genius, you forget there's a river there? I couldn't swim that far even if it weren't the middle of winter"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:384
+msgid ""
+"Hey genius, you forget about the river? I got expelled long before learning "
+"how to levitate, and the girl ’haint swimming that far even if’t it weren’t "
+"the middle of winter."
+msgstr ""
+
+#. [message]: speaker=Ritharran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:396
+msgid "Oh."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:404
+msgid "Destroy the signal beacon without raising the alarm"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:408
+msgid "An enemy sees you during their turn"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:420
+msgid "Moving past or killing enemies on your turn will not raise the alarm."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:435
+msgid ""
+"Your regular soldiers cannot sneak north with you, but you can instead "
+"recruit Footpads, Thieves, and Rogue Mages!\n"
+"\n"
+"Footpads are quick-but-fragile scouts, with equally weak melee and ranged "
+"attacks.\n"
+"\n"
+"Thieves trade the footpad’s ranged attack for improved melee damage, and are "
+"particularly deadly when attacking an enemy from behind.\n"
+"\n"
+"Rogue Mages are fragile fighters with both physical and magical attacks."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. the player has spotted a goblin or saurian on lookout duty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:573
+msgid ""
+"Take care! If that guard spots us on its turn, it’ll alert all the others."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:645
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:657
+msgid "Fog and Vision:"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:646
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"For this scenario, we’ve highlighted which hexes the goblins and saurians "
+"can see.\n"
+"If you end your turn in vision of a living goblins or saurian, you’ll lose "
+"the scenario!\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:658
+msgid ""
+"In fog, units (including yours) can see 1 hex further than their movement.\n"
+"\n"
+"On lower difficulties, this scenario specially highlights which hexes\n"
+"are in enemy vision. Because you’re playing on the highest difficulty,\n"
+"you’ll have to keep track on your own.\n"
+"\n"
+"If you’re having trouble reaching the beacon, try lowering the difficulty."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#. that one's patrolling back and forth! Those lizards are ugly
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:681
+msgid "That one’s patrollin’ back an’ forth! Those lizards sure are ugly..."
+msgstr ""
+
+#. [message]: speaker=$unit
+#. an enemy has died swiftly, without making much noise
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:695
+msgid "Urk—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:699
+msgid ""
+"Excellent! That one perished swiftly, before it had a chance to raise the "
+"alarm."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:711
+msgid "We must move swiftly! The fog is already starting to clear."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#. [message]: speaker=Ysaxis
+#. presumably these saurians have fought Delfador before. They recognize him even if he's polymorphed
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#. look, it's that wizard again! Light the fire, sound the alarm.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:741
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:770
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:787
+msgid "Look, it’sss that wisssard again! Light the fire, sssound the alarm!"
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:746
+msgid "Look, it’s that wizard again! Light the fire, sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:762
+msgid "The beacon is destroyed! And just in time too: the fog is lifting."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:779
+msgid "I’ve tarried too long, the fog is already clearing!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:807
+msgid ""
+"We’ve been spotted, and soon this outpost will be swarming with orcs! I hate "
+"running from a fight, but we have to retreat... "
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. Ysaxis is ordering his minions to light the beacon fire, but there's nobody left to light the beacon
+#. I said, light the fire!
+#. Ysaxis is ordering his minions to light the beacon fire, but the beacon is destroyed
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:818
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:829
+msgid "I sssaid, light the fire!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:821
+msgid ""
+"Cursssesss, the moutain guards are ssslain, and the beacon cannot be reached!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:831
+msgid "Cursssesss, the beacon is destroyed and the orcs still slumber!"
+msgstr ""
+
+#. [message]: role=goblin1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:852
+msgid "Eeek! It’s gone!"
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#. no matter, my saurains will slip past and warn the army! Everyone, escape to the west!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:858
+msgid ""
+"$part2_message No matter, my sssaurians will ssslip past and warn the army! "
+"Everyone, essscape to the west!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. saurians are trying to run past Delfador's army and get orcs to come fight Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:864
+msgid ""
+"They’re making a run for it! Don’t let a single one get away, or this "
+"outpost will be swarming with orcs!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:900
+msgid "Defeat enemies before any escape"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:904
+msgid "Any enemy reaches the west edge of the map"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:926
+msgid ""
+"We must defeat these saurians and escape before nightfall, or the main "
+"orcish camp will wake and be upon us!"
+msgstr ""
+
+#. [message]: speaker=$unit
+#. I have escaped!
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:939
+msgid "I have essscaped!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:943
+msgid ""
+"One of them has gotten away to warn the orcish army! I hate running from a "
+"fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: type=Orcish Warlord
+#. an orc has just woken up and found Delfador fighting saurians
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:960
+msgid "<i>Yaawwnn</i> ...what’s all this noise about?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:964
+msgid ""
+"We’ve taken too long, now it’s nighttime and the orcish camp has awoken! I "
+"hate running from a fight, but we have to retreat..."
+msgstr ""
+
+#. [message]: speaker=Ysaxis
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:982
+msgid "Cursssesss..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:993
+msgid "Ah-ha, got you!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07_The_Great_River.cfg:996
+msgid ""
+"Victory is won! We have done well to remain undetected — the way forward "
+"remains clear. Now onwards to the Swamp of Dread, to find out why these "
+"saurians are fighting alongside orcs..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:4
+msgid "Weldyn Court"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:104
+msgid ""
+"“<i>Barren Throne</i>”, “<i>Angel of Ashes</i>”; don’t people have better "
+"things to do than gossip all day about this vapid prophecy? I put my trust "
+"in steel, not seers."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:108
+msgid "My Liege, I fear you give insufficient weight to—"
+msgstr ""
+
+#. [message]: speaker=Henri
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:112
+msgid "Hold your peace, exile. Your king is speaking."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:116
+msgid ""
+"And “<i>Sceptre of the Wesfolk</i>” is the worst of it all... as if it’s my "
+"fault Haldric’s dwarves lost the accursed thing.\n"
+"\n"
+"Even the wife! Ever since she first heard that prophecy, all I get from "
+"Asheviere is gossip; rumors about nobles and expeditions and treasure-"
+"seekers and other such nonsense. This is a problem, Arand."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:122
+msgid ""
+"Well, I cannot deny that the Sceptre of Fire is well-known as our symbol of "
+"rulership, among lords and common-folk alike.\n"
+"\n"
+"My spies have heard nothing of these “expeditions”, but if they are real and "
+"one of the nobles actually manages to find and retrieve the sceptre... well— "
+"such a misfortune could put your claim to the throne in serious jeopardy."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:128
+msgid ""
+"Intrigue and influence, politics and loyalty... *sigh*. This isn’t my "
+"strength, Arand.\n"
+"\n"
+"But I use the tools I have. Take General Lionel — there’s a man to rely on! "
+"He’s served me loyally for many years; why, I practically trust him more "
+"than my own son!"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:134
+msgid "(bows)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:138
+msgid "No offense, boy."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:142
+msgid "(scowls)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/07x_Weldyn_Court.cfg:146
+msgid "Still, these rumors cannot be taken lightly. Something must be done...."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:40
+msgid "Ruins of Saurgrath"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:83
+msgid "aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:84
+msgid "female^aged"
+msgstr ""
+
+#. [trait]: id=aged2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:85
+msgid ""
+"Units with the <italic>text='aged'</italic> trait have 8 hitpoints less and "
+"suffer from a 1 point decrease in movement and damage."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:102
+msgid "Fliiss"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:103
+msgid "Messata"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:104
+msgid "Anazz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:105
+msgid "Zilnaza"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:106
+msgid "Ka'Kzaesz"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:107
+msgid "Fritrais"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:108
+msgid "Artrax"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:112
+msgid "Saurian Juveniles"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:319
+msgid ""
+"The seven saurian matriarchs lie somewhere in this swamp. With most of their "
+"warriors away at war, they will be vulnerable."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:323
+msgid ""
+"The Blackcrests have good reason to fight, but none of this should concern "
+"saurians — they’re not usually invaders. I need to figure out what’s going "
+"on with this alliance and put an end to it, even if that means roasting "
+"their slimy hides scale-by-scale!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynan, but if she's died it could be any automatically-generated human name of either gender
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:328
+msgid ""
+"That is, if we can find their camps — even what little remains of Saurgrath "
+"is too vast for us to scour it all. This is where you said your guides would "
+"meet us, right $companion_name?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:332
+msgid "You’re almost there! Jus’ a lil bit further... almost..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:346
+msgid "Rendezvous with $companion_name’s guides"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:400
+msgid "Hey, what—"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:404
+msgid "Gonnin"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:409
+msgid "Milyn"
+msgstr ""
+
+#. [event]: id=activate_poachers
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:414
+msgid "Barin"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:420
+msgid ""
+"Well well, look what the cat dragged in. You’re a little far from home, "
+"scholar!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:424
+msgid ""
+"T’would be a shame if som’thin happened to you and your coin-purse... alone, "
+"all the way out here..."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:438
+msgid "Pay up ($fee gold)"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:444
+msgid "Attack"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:476
+msgid ""
+"Great! Rest easy now that you’ve hired us; we’ll guide you ’round the swamp "
+"and make sure nothin’ happens to you or the rest of your coin! "
+"$companion_name said yer looking for them lizards, yeah?"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:492
+msgid ""
+"...what, you didn’t think we was trying to rob something, did ye? Naw, I’m "
+"your guide. I’d never hurt a friend of $companion_name’s."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:499
+msgid ""
+"Poachers are general-purpose nighttime archers, with numerous-but-weak "
+"ranged strikes and unusually good defense in swamps."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:523
+msgid "Insolent fools, I am no sickly scribe, easy pickings for the robber!"
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:527
+msgid "Whoah, hey uh, what’s going on?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:531
+msgid ""
+"You bandits trifle with an archmage of Wesnoth, famed and powerful. Step "
+"forth and meet your doom!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:537
+msgid "Defeat the bandits"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:568
+msgid "Ughhh..."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:576
+msgid "I’m gettin’ out o’ here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:585
+msgid ""
+"Serves them right, preying on innocent travelers... Now, where’s these "
+"guides of yours we’re going to meet?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Lionel
+#. [message]: speaker=Omaranth
+#. [message]: speaker=Aethyr
+#. [message]: speaker=Asheviere
+#. [message]: speaker=Garard
+#. [message]: speaker=Eldred
+#. [message]: speaker=Delfador
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:589
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:152
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:121
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:292
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:726
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:286
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:356
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:427
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:540
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:296
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:964
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1504
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:177
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:593
+msgid ""
+"Umm... you know what, I’m thinkin’ we’re better off hunting them saurians "
+"all on our lonesomes instead. I’m still gettin’ paid after all this, right?"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:607
+msgid "Defeat three of the seven saurian leaders {PROGRESS_STRING}"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:626
+msgid ""
+"Surprise attack: The saurians will not spot you until you approach within 4 "
+"hexes of a matriarch."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:647
+msgid ""
+"That saurian has different markings than the others I’ve seen, and is "
+"somewhat smaller. A juvenile or invalid, perhaps?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#. delfador has just attacked an unarmed saurian
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:655
+msgid "The monssstersss hunt usss for sssport! Flee, flee!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:659
+msgid ""
+"They really are unarmed juveniles! Hang on a minute, they’re not dangerous, "
+"maybe we should just let them be."
+msgstr ""
+
+#. [message]: speaker=$found_unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:682
+msgid "We’re under assssault! Sssound the alarm and rally our warriorsss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:686
+msgid ""
+"They’ve spotted us! The time for stealth is past; now come the fire and the "
+"flame!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:708
+msgid "Who are you! Why bring death into my homesss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:712
+msgid ""
+"I am Delfador, war-mage of Wesnoth! Abandon the Blackcrest orcs to death by "
+"Wesnoth’s spears, or I will visit upon you the same destruction your allies "
+"would bring to us!"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:716
+msgid ""
+"But tribe Earth-Becomes-Clay mussst fight Wesssnoth! The Great One has "
+"commanded us!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:720
+msgid ""
+"The “Great One”? I thought you matriarchs ran the show. Tell me, elder, who "
+"is this of which you speak?"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:724
+msgid ""
+"We sssauriansss are finally united... the Great One makesss usss... "
+"ssstrong..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:730
+msgid ""
+"Alas, she has expired. Her wounds were too great. But we have learned much — "
+"we must capture another matriarch to find out who this ’great one’ is."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:749
+msgid ""
+"You are beaten, lizard! Your ’great one’ commands you to kill my people; "
+"tell me who or what the ’great one’ is, and your life shall be spared."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:753
+msgid ""
+"Curssse you! We are all nothing but wormsss before her... she will dessstroy "
+"you in an inferno of flamesss!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:771
+msgid ""
+"And I shall destroy YOU in an inferno of flames if you don’t tell me what I "
+"want to know!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:782
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:842
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1573
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2014
+msgid "fireball"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:799
+msgid ""
+"Wait, what! I wasn’t actually going to— that wasn’t supposed to happen! "
+"Where did that fireball come from!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:803
+msgid ""
+"...it seems I’ve spent so much time building my power that I neglected the "
+"finer arts of control. Methor would be ashamed... I must redouble my efforts."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:845
+msgid ""
+"Cease your fighting, matriarch, for you have been bested! Heed this warning: "
+"answer my questions or be burned to ashes!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador was worried he would accidentally shoot a fireball, but he didn't
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:865
+msgid "(There we go. Both power and control.)"
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:869
+msgid ""
+"Mothersss protect me, can it be? Are you a sssecond great dragon of fire!? I "
+"am blessssed to sssee sssuch thingsss in my time..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:873
+msgid ""
+"A drago— your great one is a dragon!? ...yes, I am a great dragon as well. "
+"Do you not see my fire? Do you not see my flight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:880
+msgid ""
+"Now you shall tell me where I may find the dragon —the other dragon. The two "
+"of us have much business together."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:884
+msgid ""
+"Oh, Great One, I hear you and obey! Follow me, and I will guide you to your "
+"sister."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:911
+msgid "Everyone, keep moving! We’re running out of time."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:959
+msgid ""
+"What’s this? Filthy humans grubbing around in our swamp? These lizards are "
+"Blackcrest property!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:963
+msgid "They ssstrike at the matriarchsss! We ssshall ssslay them all!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg:967
+msgid ""
+"The main orcish army has caught up to us! Even if we defeat this vanguard "
+"and flee onwards, we’ve missed our chance to break the saurian alliance..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:4
+msgid "Field Hospital"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:110
+msgid ""
+"Ah, much better. Thanks again for the healing, old man, but I’m afraid this "
+"is the last we’ll be seein’ of each-other for some time."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:114
+msgid "Oh? You’ve been pulled back from the front?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:118
+msgid ""
+"Hah, not quite. Remember Delfador’s prophecy? “Line of Kings”? “Sceptre of "
+"the Wesfolk”?"
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:122
+msgid ""
+"Well, Garard’s worried. Gossip is that one of the nobles knows where the "
+"Sceptre of Fire is. I dunno if that’s true, but if a noble did get their "
+"hands on it they’d have a pretty strong claim to the throne. Garard’s throne."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:126
+msgid ""
+"The king’s sendin’ me and an entire company of Weldyn’s most finest on a "
+"’grand journey’ into the wildlands to find the sceptre first, and ensure he "
+"stays firmly in power."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:130
+msgid ""
+"A ’grand journey’ north!? Good gods, why now? Wesnoth is in enough trouble "
+"as it is, without worrying about lost artifacts and suicide missions."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:134
+msgid ""
+"I tried to convince him, but you know how Garard can be when he gets his "
+"mind set on somethin’. I only hope I can find the Sceptre quickly, and "
+"resume my place at the king’s side."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:144
+msgid ""
+"Lionel! You don’t... <b><i>have</i></b> to go, you know. You’re Garard’s top "
+"general — if you refuse, I’m not sure there’s much he could do about it."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:148
+msgid ""
+"And it would be for the king’s own good! Garard needs you <b><i>here</i></"
+"b>, Lionel! Wesnoth needs you here."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#. "I'm loyal" is the same thing Delfador says in S10x
+#: data/campaigns/The_Deceivers_Gambit/scenarios/08x_Field_Hospital.cfg:157
+msgid "I’m loyal, Methor. Always have been, always will be."
+msgstr ""
+
+#. [scenario]
+#. [unit]
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:11
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:785
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:253
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:144
+msgid "Omaranth"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:41
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:32
+msgid "Omaranth’s Flight"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:58
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:55
+msgid "Fauna"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:89
+msgid "{ON_DIFFICULTY4 60 60 60 30} gold"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:96
+msgid ""
+"Whoever cleared this place out left behind some gold. That’s {ON_DIFFICULTY4 "
+"60 60 60 30} more for the treasury."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $saurian_guide_name is a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:150
+msgid ""
+"What ails you, $saurian_guide_name? I have trusted you thus far a sign of "
+"good faith — please don’t make me regret that decision."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:154
+msgid ""
+"Oh Great One, the other Great One livesss in thessse cold mountain "
+"sssnowsss. But it is dangerousss! I am eldessst of my tribe... near "
+"sssixteen years of age. Age hasss made me weak; too weak to travel thessse "
+"landsss without help."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:158
+msgid ""
+"But you are young! You are mighty! Your fire ssshall warm usss in the cold "
+"and protect usss from the dangersss! Together, yesss, together we ssshall "
+"reach the valley!"
+msgstr ""
+
+#. [objective]: condition=win
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:174
+msgid "Move $saurian_guide_name to the marked hex"
+msgstr ""
+
+#. [objective]: condition=lose
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:183
+msgid "Death of $saurian_guide_name"
+msgstr ""
+
+#. [note]
+#. $saurian_guide_name will be a female saurian name generated with the default Wesnoth name generator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:192
+msgid "$saurian_guide_name will not follow you to the next scenario."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:213
+msgid ""
+"$saurian_guide_name, could we not have brought augurs along on this journey? "
+"I’ve mastered many forms of magic, but the light of a healer is beyond my "
+"reach."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. the matriarch assumes both Delfador and the drake are female
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:218
+msgid ""
+"Oh Great One, you know it isss forbidden! The malesss are not permitted! "
+"Only you and I; usss femalesss may look upon the other Great One; your "
+"sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:222
+msgid "Us females? Err, yes, that’s right."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:241
+msgid ""
+"So many bones! And they don’t look human... Is such death all work of your "
+"great dragon?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#. there were living drakes here only 20-30 years ago, but saurians have a very short lifespan.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:246
+msgid ""
+"No, this valley is cursssed... My grandmother usssed to sssay there were "
+"once many powerful creaturesss in thisss place, but they were ssslain long "
+"before I wasss hatched. Now only our Great One remainsss."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:250
+msgid ""
+"But once you find her, then there ssshall be two! Together the Great Onesss "
+"will be unssstoppable!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:262
+msgid "Oh Great One! Sssave me!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:278
+msgid ""
+"The sssnow, the windsss, it chillsss usss... Oh Great One, even with your "
+"warmth, we cannot ssstay here long!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:282
+msgid "We must keep moving."
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:290
+msgid "The cold chillsss me ssso! I cannot sssurvive much longer!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:298
+msgid "Ssso... cccold... Oh Great One, I have failed you..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:350
+msgid "Well?"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:354
+msgid ""
+"Yesss, oh Great One, thisss is the place! Thisss is the lair of the other "
+"Great One, your sssister, our massster, our god!"
+msgstr ""
+
+#. [message]: speaker=$saurian_guide_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:362
+msgid ""
+"Sssimply continue down the valley, and you ssshall meet your sssissster! I "
+"dare go no further. Oh massstersss, please forgive usss..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:474
+msgid ""
+"Hmmph. What’s she so afraid of; it’s just one measly dragon. I’ll burn it to "
+"cinders and call myself Delfador Dragonsbane! The poets will sing my praises "
+"through the streets of Weldyn!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:480
+msgid "After all, the heroes of old used to slay dragons all the time, right?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:486
+msgid ""
+"Well, now that I think of it, I only remember reading about one single slain "
+"dragon..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:492
+msgid ""
+"And Prince Haldric did have a whole company of the Green Isle’s best knights "
+"to help..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:498
+msgid "Uh oh."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:516
+msgid ""
+"SOMETHING STIRRS.\n"
+"A HUMAN COMES."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:523
+msgid ""
+"IT IS FEEBLE.\n"
+"IT IS WEAK.\n"
+"IT WILL DIE."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:530
+msgid ""
+"...wait a minute, that’s not a dragon, it’s merely a drake! The saurians "
+"must have mistaken it for a true dragon on account of its fire breath."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:534
+msgid ""
+"So you are the villain behind all of this. Delfador Drake-Slayer isn’t quite "
+"so catchy as Dragonsbane, but I’ll take what I can get!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:545
+msgid "Hey, get back here!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:552
+msgid ""
+"This drake is important — we cannot let it escape. My companions, I task you "
+"to guard this cave entrance while I chase the drake inside. When next you "
+"see me, I’ll be holding the beast’s scalp!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:583
+msgid ""
+"You got it, boss. We’ll watch th’ cave entrance, an’ make sure you don’ get "
+"trapped inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:594
+msgid ""
+"Sounds like a pretty easy job. All we gots to do is wait ’round ’ere for the "
+"boss to come back out."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:602
+msgid "Relax. What could go wrong?"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:612
+msgid ""
+"In this scenario $companion_name is your leader, and can recruit / recall."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:742
+msgid "Look out! One o’ them was lurkin’ just inside the cave entrance!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:753
+msgid ""
+"That’s the last one ’o them, and with all the caves collapsed there won’t be "
+"no more! Nothin’ left to do but wait for Delfador to come back out, and "
+"relax... for real this time. Great work everybody."
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:930
+msgid "Brrr... It’s suddenly so c-c-cold..."
+msgstr ""
+
+#. [message]: id=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:961
+msgid "Uhh, hello? Who’s there? Boss, is that you?"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1015
+msgid "Aaaah!"
+msgstr ""
+
+#. [message]: role=escort1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1028
+msgid "Hell no! Curse it all, I didn’t sign up for fighting zombies!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1032
+msgid ""
+"C’mon everyone, grab your weapons an’ get ready. I’ve a feeling we’re about "
+"to have the fight o’ our lives!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1071
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1103
+msgid "Protect Delfador’s cave entrance until turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1075
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1107
+msgid "Delfador’s cave entrance is destroyed"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1098
+msgid ""
+"Look, a frozen cave, jus’ like the one Delfador went down! I’ll bet these’re "
+"where all the undead are climin’ out of. Quick now, if we knock down the "
+"entrance we can trap ’em inside!"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1114
+msgid "Destroy hostile cave entrances to trap enemies inside."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1134
+msgid ""
+"Oh no... you don’ look so good. Don’ die on me now, you hear? You got lots "
+"left to live for!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1142
+msgid "RraaaAAARRRGGG!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1170
+msgid ""
+"Ghost!! This jus’ keeps gettin’ worse! How’re we supposed to fight somethin’ "
+"our weapons can’t even touch!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1191
+msgid "C’mon, don’t give up! We can pull through this!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1207
+msgid ""
+"...boss? Hey, boss, you comin’ out o’ that cave anytime soon? We could "
+"really use your help out here..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1250
+msgid "Wha— what’s happening!?"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1267
+msgid "Thank the gods! It’s finally over."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1271
+msgid "I’m alive... I can’t believe it..."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1275
+msgid "I think we won! ...but how?"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1306
+msgid "The center crypt’s collapsin’! We’ve failed!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg:1310
+msgid ""
+"We did our best, but the boss ’aint comin’ back out anytime soon. We’d "
+"better scram back down south before the same happens to us."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:4
+msgid "Houses of the Dead"
+msgstr ""
+
+#. [message]
+#. notice that appears at the beginning of the scenario if you select Brutal difficulty
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:93
+msgid "Meanwhile..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:117
+msgid ""
+"Stand and fight me, drake! You and your saurians have caused Wesnoth enough "
+"harm. In the name of King Garard, your villainy ends here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:128
+msgid "...I suppose we’ll have to do this the hard way."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:136
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:327
+msgid "Find Omaranth"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:143
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:344
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:766
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1067
+msgid "In this scenario, you can neither gain nor spend gold."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:203
+msgid "A drakish tomb? This looks ominous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:238
+msgid ""
+"A ghost! Walking corpses are a great evil, but mastery over spirits is far "
+"fouler still. Damned vessels, conscious but enslaved... yet where there are "
+"enchantments, there are opportunities."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:248
+msgid ""
+"I must concentrate. The slightest mistake in the casting of this spell could "
+"be fatal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:264
+msgid ""
+"I call upon the name of An-Usrukhar the Great. I invoke the Mirror of "
+"Evanescent Time!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:271
+msgid ""
+"I challenge life against death! I invoke freedom against order! I wield "
+"light against darkness!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:278
+msgid ""
+"May the coils of servitude be broken! Spirit of the damned, be freed from "
+"your master."
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:296
+msgid "My mind... is my own..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:300
+msgid ""
+"Speak, spectre! Tell me of this place. Where is the drake they call the "
+"“Great One”?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:304
+msgid ""
+"I do not know. I know nothing of drakes. I am a man. My name is Aethyr... I "
+"had almost forgotten. I died long ago, in a great battle..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:306
+msgid "Aethyr"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:309
+msgid ""
+"You’re the spirit of a human? How did you come to roam these drakish halls, "
+"so far from the lands of men?"
+msgstr ""
+
+#. [message]: speaker=Aethyr
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:313
+msgid ""
+"Iliah-Malal brought me here. He made me promises of life renewed, but "
+"instead bound me to his will. Perhaps Iliah-Malal will know of your drake."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:317
+msgid ""
+"A necromancer? Troubling. Yes, I should very much like to meet this Iliah-"
+"Malal."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:331
+msgid "Find Iliah-Malal"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:338
+msgid ""
+"Delfador can capture hostile ghosts by moving adjacent to them, unless he is "
+"polymorphed."
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:341
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:763
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1064
+msgid "Allied ghosts will not follow you to the next scenario."
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:376
+msgid "<span color='#008800' size='x-small'>Ghost Captured</span>"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:396
+msgid "Sythan"
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:411
+msgid ""
+"I was once a great lord... I commanded armies! Iliah-Malal promised I would "
+"lead again."
+msgstr ""
+
+#. [message]: speaker=Sythan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:415
+msgid "It was all a lie. I became only his slave."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:424
+msgid "Vellin Ka"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:442
+msgid ""
+"Your banners were red.\n"
+"Your spears were sharp.\n"
+"Your hearts were cold."
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:448
+msgid ""
+"Iliah-Malal led your army.\n"
+"Iliah-Malal burned our Eyrie.\n"
+"Iliah-Malal will die."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:454
+msgid ""
+"You’re a drake, and Iliah-Malal fought against you alongside... an army of "
+"living men? And what of the armageddon drake; how did he survive if the rest "
+"of you did not?"
+msgstr ""
+
+#. [message]: speaker=VellinKa
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:458
+msgid ""
+"Omaranth was Dominant of our Flight.\n"
+"Omaranth was strongest in our Eyrie.\n"
+"Omaranth’s fate was not seen by I."
+msgstr ""
+
+#. [message]: id=$sun_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:491
+msgid ""
+"A passage to the world above! Oh, how I long to go through and see the sun "
+"again..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:495
+msgid ""
+"Focus, $sun_name. This necromancer Iliah-Malal must have raised these "
+"corpses, and now sends them against my allies on the surface. We must not "
+"abandon our task here."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:508
+msgid "Hagha-Tan"
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:523
+msgid ""
+"The chief called me to war... I knew the attack was risky, but I was "
+"willing..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:527
+msgid ""
+"If you’re a recently-dead orc, what can you tell me about battle plans? "
+"Troop movements? Wesnoth can use any help we can get."
+msgstr ""
+
+#. [message]: speaker=HaghaTan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:532
+msgid "You are no lord of mine, man of Wesnoth. I serve only my clan."
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:542
+msgid "Melinna"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:556
+msgid ""
+"Are you a drake? Do you know anything about Omaranth, or this necromancer "
+"Iliah-Malal?"
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:560
+msgid ""
+"I know only what I knew in life, Delfador. Yes, I recognize you... Garard’s "
+"attack dog..."
+msgstr ""
+
+#. [message]: speaker=Melinna
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:564
+msgid ""
+"I was once a lady of the court. I only wanted to make peace, to stop the "
+"fighting.\n"
+"\n"
+"But the dead found me in the night. Now I find myself here, in a form "
+"reflecting my fate. Why did they hunt me? Why didn’t you keep us all safe..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:599
+msgid ""
+"There is a gate here, sealed by runic energy. My magic should be able to "
+"open it, but we must be prepared for whatever lies beyond."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:613
+msgid ""
+"Only Delfador has the power to open these gates... whatever lies beyond will "
+"be most dangerous..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:633
+msgid ""
+"Whatever lurks behind this gate, it will be dangerous. I should make sure I "
+"am prepared before I proceed."
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:635
+msgid "Open the gate"
+msgstr ""
+
+#. [option]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:640
+msgid "Wait"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:730
+msgid ""
+"You! With so many undead about I was expecting to find the necromancer... I "
+"don’t entirely understand what’s going on here, but I do know that you’re an "
+"enemy of Wesnoth, and that’s good enough for me."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:734
+msgid ""
+"YOU INVADE MY HOME.\n"
+"YOU SLAY MY SERVANTS.\n"
+"YOU UNDERSTAND NOTHING."
+msgstr ""
+
+#. [message]: speaker=Omaranth
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:740
+msgid "NOW, YOU DIE."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:756
+msgid "Defeat Omaranth"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:826
+msgid "Ah ha, ha ha ha..."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:831
+msgid ""
+"Well fought, Delfador! They warned me you were dangerous, but to have found "
+"me amidst all the vastness of the north — you have truly exceeded all "
+"expectations!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:835
+msgid ""
+"Now the story begins to make sense. The Omaranth I saw was never more than "
+"an illusion. You are Iliah-Malal."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:839
+msgid ""
+"You wiped out this flight of drakes, and took the visage of their leader. "
+"You led the saurians to join Clan Blackcrest, and you sent them to war "
+"against Wesnoth. But why? How does all this fighting benefit a mage?"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:843
+msgid ""
+"How does all <i><b>your</b></i> fighting benefit <i><b>you</b></i>? Decades "
+"of war, and what has been gained? While you bleed for a failing country and "
+"an aging king, your whole life is passing you by. You’re on the wrong side "
+"of history, Delfador war-mage."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:848
+msgid ""
+"But you don’t have to be. Walk away! Stop wasting your life in service of a "
+"warmonger, and finally act for yourself! Delfador, I have allies under whose "
+"patronage you could live like a king, if you would only accept them!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:852
+msgid ""
+"Like a king? I already serve a king, Iliah-Malal, and am well-treated for "
+"it. Protecting Wesnoth is my <b><i>duty</i></b>. King Garard is my "
+"<b><i>friend</i></b>. I hope you did not think to break me down so easily."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:856
+msgid "Bah, remain a fool, then. You will not find me so easily broken either."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:897
+msgid "Powers of darkness, confound my foes!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1057
+msgid "Find and defeat Iliah-Malal, before his undead overwhelm you"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1079
+msgid "Nice try, Delfador! You’ve only destroyed another illusion."
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1101
+msgid ""
+"So you have found the real me. No matter. I shall have you yet, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1116
+msgid "Shadows consume you!"
+msgstr ""
+
+#. [message]: speaker=Iliah-Malal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1129
+msgid "I should... have kept... my potion..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1152
+msgid ""
+"Good riddance. With the necromancer dead, his mindless minions have "
+"followed. His meddling in life and death has been the cause of great evil."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1169
+msgid ""
+"I am free... free! You have breathed into me a ravenousness for life anew, "
+"life to drain from those who roam unfettered under the pale sun. Take us "
+"into your service, Delfador; lead us to your foes! Lead us against the "
+"living!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1173
+msgid ""
+"No, no! Do not tempt me, I beg you, for that way madness lies... should I "
+"ever start down that dark path I would never become free of it."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1177
+msgid ""
+"No. But you have been of great service today, and for that you shall be "
+"rewarded with peace."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1191
+msgid ""
+"Return to your land of calm and quiet, and trouble the living no longer. I "
+"shall save my country without your help."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1215
+msgid "From the dead I came, and to the dead I return..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1216
+msgid "Rock and dust, bone and stone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1217
+msgid "Avenge my flight..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg:1218
+msgid "Good luck, Delfador... Don’t trust anyone..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:4
+msgid "Elensefar Outskirts"
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:80
+msgid ""
+"The answer is no. Garard, Elensefar has no interest in joining your little "
+"war-clique. You’ve already stirred up enough trouble; trade up the river is "
+"failing, and goblins are once again raiding my northern border."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:84
+msgid ""
+"All the more reason to join forces and wipe the orcs out! Think how much "
+"territory we could command if the northlands were fully open to human "
+"settlement."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:88
+msgid ""
+"If you were <i>winning</i>, certainly, but then we wouldn’t be speaking "
+"together here, would we? You’ve never been one for sharing the spoils."
+msgstr ""
+
+#. [message]: speaker=Maddock
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:92
+msgid "Now if you’ll excuse me, warmonger, I have a city to govern."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:100
+msgid "Damn his cowardace! Still no word from Lionel?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:104
+msgid "(stares)"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:108
+msgid "Speak UP, boy! I raised you to be a killer, not a coward!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:112
+msgid "<span size='x-small'>You hardly raised me at all...</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:116
+msgid ""
+"Oh, confound it. Why did I let those infernal rumors convince me to send "
+"away my best general and most loyal soldiers?\n"
+"\n"
+"Lionel is missing in action, Arand becomes more paranoid by the day, and you "
+"still speak softer than a mouse. This is war — Wesnoth needs a warrior "
+"prince."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:122
+msgid ""
+"Even reliable Delfador took off months ago on some wild goose chase in the "
+"northlands. Some days it feels like the whole world is moving against me... "
+"perhaps it is an omen of things to come."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:129
+msgid ""
+"The coward’s option once more rears its ugly head. Negotiate, capitulate; "
+"yield a township or two. Give unto the orcs their pound of flesh.\n"
+"\n"
+"I can already feel the kings of old judging me in my failure, my squandering "
+"of everything they fought so hard to build..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:136
+msgid ""
+"No. I will not go down in history as a failed king; a weakling, a coward "
+"powerless to protect his people against the savages beyond. I have chosen "
+"the path of war, and I will see it through to its bloody end."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/10x_Elensefar_Outskirts.cfg:141
+msgid ""
+"Riders, summon the reserves. Empty Halstead! Empty Weldyn! I want every "
+"child old enough to walk and every elder young enough to stand!\n"
+"\n"
+"In two weeks time we march across the ford and assault the Blackcrest war-"
+"camp. Come hell or high water, we will yet have our victory."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:11
+msgid "Galcadar"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:74
+msgid "Saurian Defectors"
+msgstr ""
+
+#. [side]
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:179
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1172
+msgid "Chief Ghuvog"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:259
+msgid ""
+"Saurians of Saurgrath! It is I, your Great One, bringing an even greater "
+"warning!"
+msgstr ""
+
+#. [message]: speaker=Drakefador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:263
+msgid ""
+"These orcs have, umm, conspired to betray you! You must strike first and "
+"kill them all — now hear me and obey!"
+msgstr ""
+
+#. [message]: speaker=defector4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:268
+msgid ""
+"Can it be? The Great One ssspeaksss to usss! I am not worthy! I am blessed "
+"to hear your great voice, unusssual though it may be!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:276
+msgid ""
+"Yesss, the great fiery one has sssaved usss! If the orcsss will betray us, "
+"then we mussst ssstrike firssst!"
+msgstr ""
+
+#. [message]: speaker=defector2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:280
+msgid ""
+"...caution, caution, ssomething isss not right! Where are the ssseven "
+"matriarchsss? Why does the Great One ssspeak ssso nasssally?"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:285
+msgid ""
+"Do you not sssee her majesssty? It isss not our place to quessstion the "
+"great fiery one!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:289
+msgid ""
+"Shut it, all of you! I don’t know why any of youse care what some off-brand "
+"dragon says, but don’t forget that you lizards made a deal to fight with us "
+"against Wesnoth. Even paid <i>us</i> for the priviledge, you dumb little "
+"worms!\n"
+"\n"
+"Now form up and get in line, before I have to beat some discipline into you!"
+msgstr ""
+
+#. [message]: speaker=defector1
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:299
+msgid ""
+"You insssult usss! Worssse, you dare insssult the Great One! Curssses upon "
+"you, cursses upon you! We ssshall fight you, we mussst fight you!"
+msgstr ""
+
+#. [message]: speaker=defector3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:307
+msgid "Yesss, we mussst fight! Fight the orcsss!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:311
+msgid ""
+"Oh yeah? Try me, you filthy sacks of lizard slime; I’ll teach youse your "
+"proper place! To arms, Blackcrests!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:382
+msgid ""
+"Told you — if some two-bit necromancer can learn to cast a true-to-life "
+"illusion, so can I. Just wait until Garard hears about this."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:386
+msgid ""
+"Good thinkin’, boss. Looks like them orcs and lizards are gonna cut each "
+"other to ribbons! That’s gotta be enough to finish this war o’ yours."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:390
+msgid ""
+"We have made a good start, but our fight is not done yet. This is the great "
+"western horde — these tents have been a staging ground for every Blackcrest "
+"attack on Wesnoth since they first entered the war, so many years ago."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:394
+msgid ""
+"Every time I tried to lead soldiers across the river, it was these "
+"fortifications that pushed me back. ’tis a funny feeling to finally see them "
+"from the north side..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:398
+msgid ""
+"But more to the point, this is where the Blackcrest war-chief commands his "
+"clan."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:404
+msgid ""
+"With most of the saurians defecting, this is our chance to kill the "
+"Blackcrest chief and break their grip on the Abez once and for all. It’s all "
+"led up to this! We can end things here and now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:408
+msgid "For the sake of Wesnoth, we cannot fail."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:417
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:821
+msgid "Defeat Ghuvog, the Blackcrest war-chief"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. $companion_name is probably the female name Lynyan, but might be other male or female names if Lynyan has died
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:444
+msgid ""
+"You’re sure you’re up for this, $companion_name? You’re an outlaw, not a "
+"soldier. I shan’t lie and say your help is unneeded, but neither should I "
+"take it for granted."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:448
+msgid ""
+"...fightin’ a whole orcish army is a bit more than I signed on for, but you "
+"say this is important and I trust you. I’m ready for this if you are."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:454
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than skulkin’ around picking pockets."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:460
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than runnin’ errands for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:466
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than castin’ cantrips for some thug."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:472
+msgid ""
+"And hey, if nothin’ else, at least I’ve got to admit that adventurin’ with "
+"you pays a lot better than muckin’ around in swamps all night."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:485
+msgid ""
+"Welcome to the Ford of Abez\n"
+"South: Tath\n"
+"North:<span strikethrough="
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:503
+msgid "Urgh... how did this massacre happen..."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:516
+msgid ""
+"I sssurrender, I sssurrender! Chief Ghuvog is the true Great One; my "
+"allegiance isss only to you, great chief! Pleassse, ssspare me and my kin!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:525
+msgid "Now that’s more like it! Fall into line and get ready to fight."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:539
+msgid "You betray the Great One... the stars shall bring your doom..."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:552
+msgid ""
+"Graahh!! Get out of here, you stinking pink-skins! Now is not a good time!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:564
+msgid "Out of my face, worms!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#. yes yes, Delfador probably hasn't attacked any orcs by now (and he might not be using fire). But it's a cool line.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:629
+msgid ""
+"Ah-ha! I’d recognize that smell of burning orc-flesh anywhere – Delfador has "
+"returned!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:638
+msgid ""
+"This is the chance I’ve been waiting for; my golden, glorious opportunity to "
+"crush the orcs now and forever! Once more unto the breach – captain, break "
+"me an opening through the enemy lines!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:711
+msgid "You heard the king; form up, and prepare to storm the front!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:807
+msgid ""
+"Deoran has rejoined your party, along with {ON_DIFFICULTY4 80 80 80 40} gold "
+"and your veterans (if any) from Part 1 of “The Deceiver’s Gambit”!\n"
+"\n"
+"In this scenario, Deoran is a leader — he can recruit and recall soldiers "
+"while standing on his keep."
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:829
+msgid "Death of Garard"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:858
+msgid ""
+"For Wesnoth! For victory! By battle and blood, for fury and flame, and the "
+"glory of conquest!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:888
+msgid ""
+"All right, all right, I know when I’m beat! Let’s not be hasty, there’s no "
+"need for more death and violence. <span size='x-small'>Against me, anyhow. "
+"Nasty pink-skin whelps.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:899
+msgid ""
+"Watch your tongue, vermin! I am no ’whelp’, but King Garard of Wesnoth, "
+"second of his name!\n"
+"\n"
+"And in that name, for the Kingdom of Wesnoth, I hereby annex these lands "
+"from the Great River in the south to the foothills of the Heart Mountains in "
+"the north! You orcs shall fall beneath our swords as wheat before the sythe!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:905
+msgid ""
+"...but I am no fool. Wesnoth is tired of war, and your lord Garard is "
+"nothing if not merciful. I will spare your life and the life of your "
+"warriors, on one condition.\n"
+"\n"
+"You must hereby swear an oath to gather both your clan from here, and Clan "
+"Whitefang from the hills around Fort Garard. You shall leave these lands and "
+"never return so long as I draw breath, on pain of death!"
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:911
+msgid ""
+"Yeah yeah yeah, whatever you say. We was just leaving; isn’t that right, "
+"boys? <span size='x-small'>Nasty filthy pink-skins.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:928
+msgid ""
+"After all this time... Wesnoth is finally at peace. It is as if a veil of "
+"shadows has been lifted from upon my eyes!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:932
+msgid ""
+"Delfador, you rascal, you’ve truly outdone yourself this time. They tell me "
+"how you turned the saurians against the orcs, sowed chaos from behind; truly "
+"incredible!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:936
+msgid ""
+"Delfador the “Great One”, hah! Now that’s the stuff legends are made of. So "
+"legendary, in fact..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:946
+msgid ""
+"“The Great” you were called by the enemy, and “The Great” you shall be "
+"called until the end of your days. Kneel, Delfador, war-mage of Wesnoth. And "
+"rise, “Delfador the Great”, High Advisor to the Crown!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:962
+msgid ""
+"Next time I start a war, I’ll make sure to put you in charge from the start. "
+"In fact, I may already have a few new conquests in mind..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:966
+msgid ""
+"But that’s talk for later. Now come, let us celebrate my— our— ...all right, "
+"<i><b>your</b></i> success! Victory! Victory! Victory by the name of "
+"Delfador!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:993
+msgid "Huh."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:998
+msgid "Whaddid you say, boss?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1002
+msgid ""
+"Oh, nothing. I feel like something bad normally happens if we take this long "
+"to finish a battle, but right now everything seems fine."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11_Clan_Blackcrest.cfg:1006
+msgid ""
+"We’re <i>definitely not</i> missing out on significant events happening "
+"elsewhere... events that we really should have been present for..."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:4
+msgid "Revelry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:22
+msgid "Moreth"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:119
+msgid "Three cheers for Delfador, hero of the Abez!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:123
+msgid "Three cheers— three cheers for Delfador the Great! Hurrah!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:129
+msgid "Hurrah for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:136
+msgid "Hooray for Delfador!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:143
+msgid "Hurrah for Del— *hic* Delfador!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:149
+msgid ""
+"Ha ha ha, thank you all! That’s right, I’m Wesnoth’s hero! Your hero "
+"Delfador the Great, here in the flesh!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:157
+msgid ""
+"Oh ho, someone fetch me more wine! The night’s still young; I’m ready for a "
+"proper CELEBRATION!!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:165
+msgid ""
+"I started as an inglorious apprentice, without even a name to call my own. "
+"And now I have saved all of Wesnoth, and in the process become one of its "
+"most celebrated mages! Truly, this is more than I could have ever hoped for."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:169
+msgid "I’m giddy with joy... or perhaps ’tis also the wine, heh."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:173
+msgid ""
+"My friend, you deserve it. Without their saurian allies Clan Blackcrest is "
+"on the run, and Clan Whitefang is falling back out of the eastern hills."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:177
+msgid ""
+"At long last lift the shadows of war; the realm is finally at peace. "
+"Perchance the coming days will bring laughter to the streets of Weldyn once "
+"again."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:181
+msgid "For the first time in a long time, all is finally well with the world."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:227
+msgid "*Yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:231
+msgid ""
+"Ugh, what a headache. I shouldn’t have drank so much... now nature calls."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador's woken up in the middle of the night to go use the latrines
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:247
+msgid ""
+"Disgusting. Alduin really needs to invent a spell for cleaning latrines.\n"
+"\n"
+"Mayhaps as High Advisor I can finally get someone to research that... *yawn*"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:269
+msgid "Oh!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:273
+msgid ""
+"You have startled me, your majesty. The darkest hour of night is hardly a "
+"queenly time to be about — should you not be asleep with Garard? ’tis not "
+"every day that Wesnoth wins a war."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:278
+msgid "Hello Delfador — or should I say, “Delfador the Great.”"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:282
+msgid ""
+"Such pleasure to once more speak with my husband’s famous right hand. I "
+"never did properly thank you for returning me back to him, all those years "
+"ago."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:290
+msgid ""
+"You’re a powerful man, a <i>dangerous</i> man, Delfador. I pity the fool who "
+"finds themselves on the wrong end of your staff... yet I oft pity even more "
+"so the fool who rules behind it, so consumed by the minutiae of war."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:295
+msgid "Err... I’m not sure I follow, your highness—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:308
+msgid ""
+"What’s going on here? Careful, Delfador — don’t believe a word she says."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:312
+msgid ""
+"Woman, are you not satisfied with my son; you must have my wizard too!? Away "
+"with you, wench, and save your lacquered tongue for another day!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:316
+msgid ""
+"Peace, peace! Wesnoth stands triumphant; there’s no need for quarreling!"
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:320
+msgid ""
+"It’s quite all right, Delfador; I take no offense at my husband’s cruel "
+"words. Far be it from me to interfere in military matters — the king and his "
+"new advisor have doubtless much to speak on. I graciously make my leave."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:333
+msgid ""
+"That seemed a little extreme, m’lord! Surely a little politeness would not "
+"go amiss, especially with regards to your very own blood! I’ve heard nothing "
+"but praise for the queen from most of the court."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:337
+msgid ""
+"They don’t know her. You don’t know her— ...where’s that wine from earlier? "
+"Got to take my mind off things."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:348
+msgid ""
+"King Haldric, Queen Jessene... the first royal family, Delfador— the firsts. "
+"Great rulers... great people... My ancestors led our people to found the "
+"entire realm of Wesnoth, the entire race of men!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:352
+msgid ""
+"Those two understood each other. They protected their nation; saved us all "
+"from the lich lords. They raised a strong prince, a good son."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:361
+msgid ""
+"Wizard, you’ve known me for many years. You’re my royal advisor. But more "
+"than that, I count you as a friend; <b><i>a friend</i></b>, Delfador. I must "
+"know your mind — and please, answer me truthfully. Delfador, am I a good "
+"king?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador can't stand up to or speak ill of Garard, even when Garard asks him to
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:366
+msgid ""
+"You— are a <b>great</b> king, my lord! See what you and I have achieved "
+"together! The ford is seized, Fort Garard is safe, the northerners are "
+"broken!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:371
+msgid "Hmph."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:376
+msgid ""
+"I don’t know Delfador, I just don’t know. I’ve made so many mistakes. Maybe "
+"it’s the drink talking, maybe it’ll all be better tomorrow..."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:405
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:363
+msgid "<span size='x-small'>Father.</span>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:410
+msgid ""
+"Boy? This is pleasant surprise; I thought you were with your uncle, guarding "
+"my fort. Heard about Delfador’s heroics, did you? It is good to see you "
+"again."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:415
+msgid ""
+"Hold on, what’s the matter with— you’re <b><i>injured</i></b>!? What "
+"happened! Where’s that useless Methor when you need him?!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:423
+msgid "<span size='x-small'>It’s about your—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:431
+msgid "...father, it’s uncle. Prince Arand."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. Eldred doesn’t show a lot of emotion here. He's lying, and not very good at it
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:437
+msgid ""
+"He’s declared his claim to the throne. He seized control of Fort Garard. My "
+"bodyguards and I tried to stop him, but we didn’t even get close. I barely "
+"made it out alive."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:441
+msgid "Arand tried to kill me, father. He’s coming for you next."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:447
+msgid "Garard—?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:451
+msgid "<b><i>WHAT!?</i></b>"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:461
+msgid ""
+"That TREASONOUS son-of-a, son-of— I knew— knew he was acting dodgy lately."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:465
+msgid ""
+"It all makes sense now. The spies found nothing because they’re HIS spies! "
+"And he cautioned me about the sceptre — cautioned me so that I would send "
+"Lionel away, send away my most loyal general!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:470
+msgid ""
+"How DARE he threaten me? How DARE he lay a finger on you? I’ll see him hang "
+"for this. DEAD, you hear me!? DELFADOR, get over here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:480
+msgid "My king, what’s going on? I couldn’t help but overhear some of—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:484
+msgid ""
+"DELFADOR! High advisor, take command of the cavalry; my personal royal "
+"cavalry — they’re the only ones I still trust. Ride to Fort Garard and burn "
+"it to the ground, TO THE GROUND!!"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:488
+msgid ""
+"I want every one of those traitors dead! And return with Arand’s head— his "
+"head, his HEAD! Or don’t return at all, DO YOU HEAR ME!?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:493
+msgid ""
+"What?! I don’t understand! Arand would not do such a thing; this is all too "
+"sudden!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:497
+msgid ""
+"Delfador, the king’s mind is clouded by drink and sleep. Do you not see he’s "
+"jumping to extremes?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:506
+msgid ""
+"Decisions!? Talk not of treason — your king has given you an ORDER. You will "
+"obey."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:514
+msgid "Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:524
+msgid "...err look, m’lord, maybe Deoran’s right abou—"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:528
+msgid ""
+"Delfador, I TRUSTED you. I LIFTED YOU UP from amidst your peers. I gave you "
+"power, prestige, and a position the envy of men twice your age. And now, I "
+"have given you an order. What are you going to do?"
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:533
+msgid "I want you to think very, very carefully before you answer."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:552
+msgid ""
+"All right, all right! Deoran I’m sorry, but... fire and destruction is what "
+"I do. I didn’t even have a name before I first began to battle!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:556
+msgid ""
+"I’ve lived half my life fighting alongside the king, fighting to earn a name "
+"for myself. Without that, who am I?"
+msgstr ""
+
+#. [unit]: type=Knight
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:563
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:391
+msgid "Sir Kaylan"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:580
+msgid "Delfador, if you would but—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. this the same thing Lionel says in S08x: I'm loyal
+#: data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg:586
+msgid ""
+"I’m loyal, Garard. It is my duty to stop those who oppose you, even if it is "
+"your own kin. Royal cavalry, form up on me! We go at once!"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:11
+msgid "The Traitor"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:29
+msgid "Royal Cavalry"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:56
+msgid "Luraery"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:71
+msgid "Aelyn"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:273
+msgid "Fall back! Hold the walls, protect the fort!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:347
+msgid ""
+"The scouts bring grim news — a fearsome army rides against us! Long have I "
+"dreaded this moment. Rally together, fight as one, and we will assuredly "
+"triumph in the coming civil war!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:373
+msgid ""
+"Curses, we have already been spotted. Time is of the essence; we must strike "
+"before Arand can turn more Wesnothians to his cause!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:409
+msgid ""
+"The king’s personal cavalry stands at your command, great Delfador! Direct "
+"us as you will, and the traitor prince shall fall beneath our hooves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:417
+msgid "Defeat Prince Arand"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:442
+msgid ""
+"Your veteran soldiers have been left behind with Deoran <b>(you’ll see them "
+"again next scenario)</b>, but you can instead recruit Cavalrymen and "
+"Horsemen!\n"
+"\n"
+"Cavalrymen are general-purpose mounted infantry, with moderate damage for a "
+"moderate price. Horsemen are more expensive, but their risky charge attack "
+"deals heavy damage."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:457
+msgid ""
+"Garard’s Royal Cavalry are loyal and skilled, but neither Horsemen nor "
+"Cavalrymen are well-suited for fighting Arand’s army of Spearmen and "
+"Pikemen. My magic shall have to make up the difference."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:461
+msgid ""
+"If only my outlaws and veterans could have marched fast enough to keep up. "
+"If the king’s own brother is an usurper, who in Wesnoth can I really trust?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:474
+msgid "Sorry about this!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:486
+msgid "Fight on without me, friends! Fight for our king!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:498
+msgid ""
+"There’s right where I’d stood, back when I fought my first real battle. How "
+"simple everything seemed back then..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:510
+msgid "Welcome to Garard’s Wold, last civilized town north of the Great River."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:559
+msgid "Such devastation. Garard’s orders have been followed to the letter..."
+msgstr ""
+
+#. [message]: role=peasant
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:568
+msgid "Help, help! What’s going on!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:572
+msgid ""
+"No hesitation; our king commanded us to raze the usurper’s estate, and "
+"that’s what we shall do. Burn it all down!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:576
+msgid ""
+"Stay your hand but a moment! ’tis not this man’s fault his lord has turned "
+"traitor. Make yourself scarce, peasant."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:612
+msgid ""
+"The rebellion is broken! In the name of King Garard and the royal scepter, I "
+"strike you down!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:617
+msgid ""
+"King Garard?! My brother sent you? But I thought—? Wait, stop, please, I "
+"don’t understand!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:630
+msgid ""
+"The young prince told us how you tried to claim the throne for yourself, "
+"Arand. You are mortally wounded — confess now, and your brother may forgive "
+"you in death."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:634
+msgid ""
+"By the sceptre, I swear I have never conspired against my brother Garard. "
+"Eldred is the traitor! Eldred and Asheviere are the traitors, not I!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:643
+msgid ""
+"My life runs short; you must believe my tale. For some time now my spies "
+"have heard whispers of a terrible conspiracy, a plot to overthrow the very "
+"king himself.\n"
+"\n"
+"Twas not a fortnight hence that my suspicions were confirmed — I gained "
+"incontrovertible evidence proving the chief conspirators to be none other "
+"than the queen and the prince, two of my brother’s closest companions!"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:649
+msgid ""
+"Yet no sooner did this news arrive than my bodyguards and I were set upon by "
+"Eldred himself, so bold as to strike even during the day!\n"
+"\n"
+"I slew several of his fighters and grievously wounded the young prince, yet "
+"barely escaped to Fort Garard before my guards were overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:655
+msgid ""
+"And now it seems that Eldred has found a way to finish me off after all..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:660
+msgid ""
+"I sense the ring of truth in your words... But if what you say is true, why "
+"fight when we approached instead of surrender? To my eyes, your resistance "
+"only sealed your guilt."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:665
+msgid ""
+"Can you blame me? Rolling waves of mud smashing my fortress to bits — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:672
+msgid ""
+"Can you blame me? Rolling waves of fire burning my fortress to cinders — I "
+"thought this some foul magic of the queen’s, here to finish what Eldred "
+"failed to do! For many months now have suspected the influence of a "
+"necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:679
+msgid ""
+"Can you blame me? I thought your cavalry and magic to be more of the same — "
+"servants of the queen, here to finish what Eldred failed to do! For many "
+"months now have I suspected the influence of a necromancer most powerful..."
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:685
+msgid "But if you are here with me, then Eldred is alone with the king?"
+msgstr ""
+
+#. [message]: speaker=Arand
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:700
+msgid ""
+"So much blood... please, you must believe me! Save my brother... save "
+"Wesnoth..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:743
+msgid "Prince Eldred? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:753
+msgid "There he is! Get him!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/12_The_Traitor.cfg:761
+msgid "Huh? Wha—"
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:23
+msgid "Revelry, Revisited"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:41
+msgid "Deoran’s Company"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:73
+msgid "Sir Grey"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:100
+msgid "Sir Johan"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:107
+msgid "Sir Gwido"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:171
+msgid "I’ve pillaged $gold_pickup gold from Eldred’s treasury!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:288
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:292
+msgid "So."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:300
+msgid "Guess yer th’ boss now."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:304
+msgid "It would seem as such. Would that Delfador had stayed."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:326
+msgid ""
+"Hey, is it true what they says? Tha’ elves are th’ greatest bestest most "
+"beautifulest creatures there are? I’ve always wanted to meet ’em."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#. referencing the events of TSG
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:331
+msgid ""
+"Elves? No. Be not fooled by a pretty face — I have seen even the noblest "
+"elven sage corrupted to such darkness as to rival the foulest human or orc."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:335
+msgid ""
+"Although, I suppose there is at least one young elf of my acquaintance to "
+"whom I might ascribe such virtues. My thoughts find her often, in these dark "
+"times."
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:356
+msgid "Sir, Delfador and the Royal Cavalry are out of sight."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:367
+msgid "All healed up? Excellent. We’ll soon put this rebellion to rest."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:371
+msgid ""
+"I admit, I was worried about you, son. <i>“Soft”</i> I thought — if I should "
+"fall, could you truly lead our people to victory? I wanted to toughen you up."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. I think this is the only time Garard actually calls Eldred by his name. Not "boy" or "son"
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:376
+msgid ""
+"But now? Sniffing out treachery in our own family? Taking it upon yourself "
+"to bring Arand to justice! You may have failed to defeat him, but failure "
+"does not diminish the trying. You did well today, Eldred."
+msgstr ""
+
+#. [message]: speaker=Garard
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:402
+msgid "(shocked) You—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:425
+msgid "<span size='x-small'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:430
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:438
+msgid "<span size='x-small'>You all saw tha—</span>"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:442
+msgid "(gulp, deep breath)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:450
+msgid "You all saw that! DEORAN HAS SLAIN THE KING!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:454
+msgid "What!? I—"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:458
+msgid ""
+"He strikes in cold blood, at the height of my father’s triumph! He takes "
+"revenge for his long years of exile! Only a heart shaped by hate and twisted "
+"by elves could commit such a foul deed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:462
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:952
+msgid "You—"
+msgstr ""
+
+#. [message]: speaker=eldred4
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:466
+msgid ""
+"Calamity! The ambassador always seemed so polite! How could he do this? How "
+"could we let him do this?!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:470
+msgid "I—"
+msgstr ""
+
+#. [message]: speaker=eldred3
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:474
+msgid ""
+"We all know Deoran’s quarrels with the king. All this while he must have "
+"been biding his time, plotting his revenge! And look, that outlaw of "
+"Delfador’s stands beside him, witness and accomplice to the crime!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:479
+msgid ""
+"No, no! $companion_name is not my accomplice— I mean, neither of us are "
+"accomplices— that is to say—"
+msgstr ""
+
+#. [message]: speaker=eldred2
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:487
+msgid ""
+"I knew it was a bad idea to let rabble like that back into our homeland! Get "
+"them both; avenge the king!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:520
+msgid ""
+"(aghast) Horrors below, Garard’s own son; what has happened to my beautiful "
+"kingdom? How—"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:524
+msgid ""
+"I don’t— what do I do? They all believe Eldred!? I’m not ready for a fight!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:529
+msgid ""
+"Listen boss, I ’aint much fer politics, but I knows when to run and that’s "
+"now! We’ve got to get out of here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:533
+msgid ""
+"I— yes, you’re right! With Garard dead, Delfador commands the greatest "
+"honest force left in Wesnoth, and he has no idea what has just transpired! "
+"Delfador must be warned."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:537
+msgid ""
+"If we are lucky, we may yet be able to save Arand from Delfador’s ill-"
+"informed assault. But even barring that, Delfador’s leadership can surely "
+"rally enough soldiers to oppose Eldred by force of arms!\n"
+"\n"
+"$companion_name, go, now! Slip away along the eastern road!"
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:548
+msgid ""
+"Wait jus’ a moment! How come you yerself ’aint movin’? Don’t be stayin’ "
+"behind to sacrifice yourself or nothin’ like that now, you hear?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:552
+msgid ""
+"Nothing so heroic. Wesnoth’s forces may believe me a consiprator now, but I "
+"will not give up on them so easily. If I fight my way into a private "
+"audience with each leader I’m sure I can make them see the truth about "
+"Eldred — Garard’s poor family relationships were no secret.\n"
+"\n"
+"Even if I can but convince commanders to delay their support for the traitor "
+"prince, that will give Delfador and me much-needed time to gather gold "
+"before our next battle!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:558
+msgid ""
+"<i>Defeating enemy leaders will increase your starting gold in the next "
+"scenario.</i>"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:562
+msgid ""
+"When at last my strength is spent, I will flee through the forest — my steed "
+"is elf-stock, and no rival bred in Wesnoth can outpace its haste amongst the "
+"trees. But the more support I can garner now, the better our position will "
+"be in the future!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:566
+msgid ""
+"Now make haste, and godspeed! You must reunite with Delfador; I will send "
+"what soldiers I can spare after you!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:574
+msgid "Avenge the king! Don’t let them escape!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:621
+msgid "$gold_pickup gold"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:636
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1218
+msgid "Defeat as many enemy leaders as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [objective]: condition=win
+#. $|escape_turns_remaining is probably between 0 and 10
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:642
+msgid ""
+"Evacuate veteran units along the eastern road ($|escape_turns_remaining "
+"turns remaining)"
+msgstr ""
+
+#. [note]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:649
+msgid "When an enemy leader is defeated, their remaining soldiers will flee."
+msgstr ""
+
+#. [note]: description=<b>
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:653
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1105
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1226
+msgid "This is the second-to-last scenario."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:679
+msgid ""
+"Units that escape to the east will be available to recall in the next "
+"scenario, but units that do not escape will be lost (either scattered or "
+"killed) — including units on your recall list! The eastern path will remain "
+"open until the end of turn {ESCAPE_TURNS}.\n"
+"\n"
+"You should evacuate enough veterans to have a strong recall list next "
+"scenario, but also defeat enough enemy leaders so that you’ll have gold for "
+"recalling."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:708
+msgid ""
+"Fleeing too quickly will only seal my guilt in the eyes of Wesnoth’s "
+"commanders. I do not intend to run until I have no other choice!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:722
+msgid ""
+"I hear orc-drums approaching the eastern road! Any more who wish to flee — "
+"now is your last chance."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:727
+msgid "I hear orc-drums approaching the eastern road! Our time runs short."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:759
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1119
+msgid ""
+"You will now start the next scenario with $bonus_gold total gold (plus "
+"$s11_carryover carryover from Delfador)"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:764
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1124
+msgid "You will now start the next scenario with $bonus_gold total gold!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:780
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough. And now that this keep is ours, I can "
+"recruit more soldiers to aid in the fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:785
+msgid ""
+"One leader is defeated. I had hoped to gain a new ally, but depriving Eldred "
+"and buying time is good enough."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:790
+msgid ""
+"I should remember — soldiers I evacuate east will be available to fight "
+"Eldred later, but if I evacuate too many I will be too weak to fight "
+"effectively here!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:802
+msgid "So much ill will... The captains of old would have died for their king."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:806
+msgid ""
+"Perhaps it is not a coincidence that so many of the old guard fell in battle "
+"against the orcs."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:839
+msgid ""
+"You are defeated, mage! Lend me your ear and hear the truth about Garard’s "
+"death! ’twas not I who struck the blow, but Prince Eldred!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:843
+msgid ""
+"I’m not stupid, Deoran; I’ve heard the whispers about how Asheviere is "
+"raising her son. But isn’t it all for the best? Garard wasn’t going to give "
+"up warmongering until we were all dead; at least this way maybe I can get "
+"back to Alduin in one piece!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:849
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; lead your magi home, "
+"and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:854
+msgid ""
+"You care so little for the affairs of Wesnoth? Then go; return home to "
+"Alduin, and trouble the mainland no more."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:876
+msgid ""
+"*spits* Traitor. Kill me if you must, but I will never betray my country."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:880
+msgid ""
+"My comrade-in-arms, you already have. Look around! Eldred commands you to "
+"fight and die on his behalf, while he himself has fled the battlefield.\n"
+"\n"
+"Are these the actions of an orphaned son, filled with a righeous desire for "
+"vengeance? Or is this a scheming usurper, pitting his kingdom against itself "
+"while he watches from a safe distance?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:886
+msgid ""
+"You know me, Sir Grey; we have fought side by side for many years now. Do "
+"you truly believe that I would conspire with Delfador to assassinate the "
+"king?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:891
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think. Men, let’s get out of here!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:896
+msgid ""
+"I *thought* I knew you... I’m just not sure anymore. Who speaks the truth? "
+"Maybe I need to get back to Dan’Tonk, away from all this fighting, and take "
+"time to think."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:916
+msgid ""
+"Colonel! You’re a man of experience, and a man of wisdom. Do you not care "
+"for your king? Do you truly believe that it was by my hand he fell?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:920
+msgid ""
+"I cared for Garard, but I care even more for the soldiers and common folk of "
+"Wesnoth, folk who have just been plunged into civil war."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:924
+msgid ""
+"Whether the deed was done by your hand or Eldred’s, it is my duty as a "
+"commander to end the fighting as swiftly as possible. And that means "
+"crushing your revolt."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:928
+msgid ""
+"You poor fool... can you not guess what horrors will come with a kin-slayer "
+"on the throne? Sometimes we must fight not just for the people of today, but "
+"for the people who will come after."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:932
+msgid ""
+"I should finish you off, but your heart is in the right place. I cannot bear "
+"to slay a righeous man. Begone."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:956
+msgid ""
+"Don’t even start. Garard dragged me away from my life of luxury to be an "
+"officer in his lousy war. I always wanted him dead, and I’m glad someone "
+"finally built up the courage to do it."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:960
+msgid ""
+"Kill me if you must, but I’ll never condemn the prince’s actions. From what "
+"I hear, Garard was a pretty lousy father and husband too. Now am I free to "
+"go, or not?"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:968
+msgid ""
+"That’s what I thought. Now get out of my way — my men and I are going back "
+"home to Weldyn."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:988
+msgid ""
+"Your sword has failed you, knight of Wesnoth! Now use your ears instead, and "
+"hear the truth about our King Garard’s death!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:992
+msgid ""
+"Spare me the theatrics, Deoran. I know Eldred’s the one who took down the "
+"old tyrant."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:996
+msgid ""
+"But gold is gold, and the prince has offered my wife and I a whole lot of it "
+"to stick with the “official” story.\n"
+"\n"
+"Prince Eldred knows how to reward his allies. Give up now, accept the blame, "
+"and he might even let you spend the rest of your days back in exile instead "
+"of prison."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1002
+msgid ""
+"Garard was no hero, but you, soldier, are a villian. May your heirs prove "
+"wiser than you were."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1020
+msgid ""
+"Wait, please don’t kill me Deoran! I know that you would never betray "
+"Garard, but what do you expect me to do about it!? If even the king can be "
+"killed, what hope do I have if I speak up?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1024
+msgid ""
+"Then stand alongside me, and we will fight together for the truth! Eldred’s "
+"lies cannot be allowed to spread."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1028
+msgid ""
+"Fighting together with you didn’t do the king much good, did it? No, my "
+"company and I are getting back to Tath while we still have the chance! Maybe "
+"the witch will know what to do next..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1034
+msgid "...witch?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1052
+msgid ""
+"Stand down! Hold your sword and hear me out! By the very sceptre itself, I "
+"swear I did not kill the king!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1056
+msgid ""
+"Wait, what!? King Garard is dead!? I heard a commotion in camp and sent my "
+"fighters to help — how did the king die? What are you doing here?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1060
+msgid ""
+"Your ignorance is truly a relief to hear, for Prince Eldred has slain the "
+"king, and blamed me for the fell deed! I have been fighting most fiercly "
+"against Eldred and his allies. If you are in any shape to help, I could "
+"sorely use your aid."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1064
+msgid "I— yes, of course! Anything I can do."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1084
+msgid ""
+"That’s the last of the leaders. Eldred has been deprived of his entire "
+"northern force! Well done, well done all!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1089
+msgid ""
+"All that now remains is for us to hold as long as possible, and be a "
+"nuisance to Eldred’s orcish allies! The longer we survive, the longer "
+"Delfador will have to prepare!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1097
+msgid "Survive as long as possible (bonus gold next scenario)."
+msgstr ""
+
+#. [message]: speaker=Ghuvog
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1199
+msgid ""
+"Grah ha ha ha, thanks for the tip-off, kid! Time for Chief Ghuvog to have a "
+"little fun with all youse pinkskins!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1203
+msgid ""
+"<i><b>Just</b></i> the rebels, beast — remember our deal. Stay north of the "
+"river and you shall be rewarded most generously once Mother and I have "
+"consolidated our control."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1208
+msgid ""
+"Eldred has betrayed our strife to the orcish clans! With grunts swarming "
+"along the riverbank, the road east to Delfador is no longer safe. There will "
+"be no more escape that way."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1319
+msgid ""
+"Deoran’s still putting up a fight! Reinforcements — call reinforcements from "
+"across the river!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1386
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. Any allies yet standing, "
+"scatter, scatter to the hills! It is me they will chase, not you."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1390
+msgid ""
+"And as for me, well, I may have cut things rather closer than I had planned. "
+"But what’s done is done — my thoughts must now turn to flight. Make haste, "
+"my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1395
+msgid ""
+"Agony! My arm goes limp, I can fight no longer. This may be cutting things "
+"rather closer than I had planned, but what’s done is done."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1399
+msgid "My thoughts must now turn to flight: make haste, my loyal steed!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1442
+msgid "(grins)"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1447
+msgid ""
+"Well, well, if it isn’t Deoran the exile, one-time commander of the South "
+"Guard; a soldier to the very end. I’ve heard all about you, you know. A "
+"perfect example of who not to be."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#. "black bottle" foreshadowing
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1452
+msgid ""
+"Did you really think you could win? Even if you had bested my army — yes, "
+"it’s <b><i>my</i></b> army now — I now carry with me so much magic that I’ll "
+"never have to lose another fight."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1457
+msgid ""
+"At last the usurper dares to face me, now that I am too injured for battle. "
+"He knows his actions are unforgivable. He knows he cannot face me in a fair "
+"fight."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1461
+msgid ""
+"I also know you’re a man of your word, so I’m going to give you a choice. "
+"You can surrender, leave Wesnoth, and swear to never again raise arms up "
+"against my rule."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1465
+msgid ""
+"Or you can fight, die, and have your corpse hoisted upon the walls of Weldyn "
+"as a warning to others. Which will it be, exile?"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1469
+msgid ""
+"More than anything does my spirit yearn to go on fighting, to risk it all on "
+"a chance at vanquishing the one responsible for all this wretched "
+"destruction!"
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1473
+msgid ""
+"But my heart remembers better places, happier times. There are... people I "
+"wish to speak to, things I have left unsaid..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1477
+msgid "Prince Eldred, I lay down my arms and accept your offer of surrender."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1500
+msgid "Idiot."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1508
+msgid ""
+"<span size='x-small'>Not a deceitful bone in his body. I didn’t even have to "
+"drink the potion. That’s... a relief.</span>"
+msgstr ""
+
+#. [message]: speaker=Kestrel
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1512
+msgid "The traitor is vanquished! Now hail, hail to your new king!"
+msgstr ""
+
+#. [message]: id=$speaker1_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1526
+msgid "Hail King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker2_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1537
+msgid "Hail, long live King Eldred!"
+msgstr ""
+
+#. [message]: id=$speaker3_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1548
+msgid "Long live the king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13_Revelry_Revisited.cfg:1556
+msgid "Yes. Long live the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:4
+msgid "The King is Dead"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:99
+msgid "Gods... what a fool I have been."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:104
+msgid ""
+"Whitefangs, Blackcrests. Saurians, Arand. I really thought I was doing "
+"something great; fighting the good fight for king and country."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:108
+msgid ""
+"But when it really mattered, I couldn’t see past my own ego. What kind of "
+"advisor was I? What kind of <b><i>friend</i></b> was I?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:112
+msgid ""
+"’tis a dark day indeed. Rebels and deserters rampage across the countryside, "
+"pillaging and looting, while the false King Eldred does nothing. Worse than "
+"nothing: he marches on our own settlements, consolidating his power!"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:116
+msgid ""
+"Our king has perished, our kingdom in peril! Are we to stand idly by and "
+"watch it fall, o’ great Delfador?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:121
+msgid ""
+"I’m not “The Great” anymore, $horselord_name. Was I ever? Everything I ever "
+"achieved was either a lie or has already been undone."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:125
+msgid ""
+"Our company is strong, but what power have we to lay low the walls of "
+"Weldyn? To wreak fire and lightning through the streets until finally I "
+"excise the festering boil at the heart of all this madness? If only."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:130
+msgid ""
+"I may not have killed the king personally, but I might as well have. And now "
+"I’m nothing."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:148
+msgid ""
+"Nothing? My erstwhile apprentive, to me you mean <b><i>everything</i></b>."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:152
+msgid ""
+"Methor!? How have you found me? I didn’t even know you’d survived the coup!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:157
+msgid ""
+"I know your flaws, but I also know your virtues. The boy I raised was rash, "
+"impulsive, and irreverent, yet within him lay a good heart. You call "
+"yourself nothing? I call you <b><i>Delfador the Great</i></b>!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:161
+msgid ""
+"Not for your lost accolades, not for your undone achievements or your false "
+"victories or even your mind-boggling magical might. No, I call my apprentice "
+"<b><i>great</i></b> because even though he made mistakes, he never let "
+"himself be defined by them."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:165
+msgid ""
+"Though the darkness ringed close, he never gave up fighting for what was "
+"right. I never gave up on you then, and I know you would never give up on "
+"Wesnoth now!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:169
+msgid "But, I—"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:188
+msgid "Thank you."
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:195
+msgid "Then, we fight?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:200
+msgid "Then, we fight!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:210
+msgid ""
+"Our king may have fallen, but that does not mean we are helpless. Garard’s "
+"killer is on the march, and on the march he is exposed. Eldred thinks he’s "
+"won; that his opposition is scattered and afraid. I say, it is Eldred who "
+"should be afraid!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:214
+msgid ""
+"For the first time in my life, I see the true enemy. I shall make things "
+"right. I shall atone for my misdeeds! Whether it takes one year or a "
+"hundred, I <b><i>will</i></b> see the throne of Wesnoth restored."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/13x_The_King_is_Dead.cfg:219
+msgid ""
+"Scouts, take my seal! Spread the word; all of Wesnoth must know of Eldred’s "
+"treachery!\n"
+"\n"
+"The rest of you, MAKE READY! We march to kill the king."
+msgstr ""
+
+#. [scenario]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:4
+msgid "Long Live the Queen"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:22
+msgid "Delfador’s Rebels"
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:69
+msgid "King Eldred"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:227
+msgid ""
+"A heroic duel, Delfador? Really? You forget that I have an army on my side."
+msgstr ""
+
+#. [side]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:315
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:328
+msgid "Wesnoth Auxiliaries"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:572
+msgid "No! Methor... Don’t die!"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:576
+msgid ""
+"Delfador, my sweet, wonderful apprentice... I couldn’t be more proud of "
+"you..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. callback to S01 where Methor complains about Delfador not learning a seeker spell
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:598
+msgid ""
+"Look at the length of that column! The prince — the king, I suppose — must "
+"have picked up more soldiers at Tath, when he forced Sir Gwido to swear "
+"fealty. Your seeker spell was excellent, Delfador; we’ve been able to find "
+"and intercept Eldred before he could turn anyone else to his cause."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:602
+msgid ""
+"Boss, how’s we supposin’ to fight that many! E’en we could, what about tha’ "
+"queen Asheviere back in Weldyn?"
+msgstr ""
+
+#. [message]: speaker=$horselord_id
+#. "reigns" is a pun - "reigns of power", but also the kind of reins that you use to control a horse (this is a mounted unit speaking)
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:607
+msgid ""
+"Indeed! Word is she’s killed half of the court and paid off the rest; the "
+"remaining lords of the city are loyal only to her! Eldred may be king, but "
+"Asheviere holds the reins."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:611
+msgid ""
+"We don’t have to fight the entire army or deal with Weldyn. The capital is "
+"too well-defended for us to sack outright — Eldred is the objective here."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:615
+msgid ""
+"Once the truth gets out about Garard’s death, we’ll have enough allies to "
+"liberate Weldyn and more besides. But only if we can stop Eldred here and "
+"now — can prove to the watchers that this coup is not yet over; that justice "
+"and honor and hope still live in Wesnoth! That’s our goal today."
+msgstr ""
+
+#. [message]: speaker=$companion_id
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:620
+msgid "Look sharp, I think they’ve spotted us!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:628
+msgid ""
+"Delfador, welcome! I was wondering if we’d get an appearance from you old "
+"has-been! ’fraid you’re not as popular with mother and me as you were with "
+"old Garard."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:636
+msgid ""
+"Opposing me is hopeless, old mage. But it’s not too late to save yourself — "
+"surrender now, disband your little rebel rabble, and we can tell the men it "
+"was all a big misunderstanding."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:640
+msgid ""
+"Just lay down your staff and greet me with open arms. You can even have your "
+"old title back! “Delfador the Great”, High Advisor to the Crown — don’t you "
+"agree that has a nice ring to it?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:644
+msgid ""
+"I am no longer so foolish as to be tempted by <b><i>that</i></b>, young "
+"prince! Enough blood has been spilled on your behalf; stop this madness and "
+"give up the throne, or I shall make you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:648
+msgid ""
+"Oh no, I don’t think so. You forget you’re speaking to your king, old man. "
+"Solders, attack! ATTACK!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:658
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1009
+msgid "Defeat Eldred"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:738
+msgid ""
+"Eldred, you know full well that your father and I were close! Is this what "
+"he would have wanted? His kingdom turned against itself, his townships "
+"pillaged by orcs? He had hope; a future for Wesnoth! A future for you!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:742
+msgid ""
+"A future for me? I can count on one hand the times the old tyrant had "
+"anything kind to say about me."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:746
+msgid ""
+"I wasn’t going to wait around to be disinherited, or worse. It was always "
+"going to be him or me — I just beat him to the finish."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:750
+msgid ""
+"Fool. I will not bandy words with whatever madness has taken root inside "
+"your mind, Eldred. Garard was harsh; I cannot deny that. But you’re a fool "
+"if you think he ever felt anything but love for you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:757
+msgid ""
+"I’m no fool, Delfador. Day and night, my parents fought. Whether said in "
+"truth or in anger, there’s some things my father can never take back."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:761
+msgid ""
+"And don’t think that I have any illusions about what sort of snake mother is "
+"either. I know, believe me. But she’s the snake who’s made me king, and "
+"that’s good enough."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:773
+msgid ""
+"I’m surprised you haven’t given up yet, wizard! But you’re no stranger to "
+"hopeless fights, are you — you bested Malal, escaped the frozen north, "
+"scattered our saurians."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:777
+msgid ""
+"Malal was powerful; <i>really</i> powerful. The fate of the whole kingdom "
+"changed, that day he and mother first met. You weren’t supposed to survive "
+"him... you weren’t supposed to survive <i><b>any</b></i> of that."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:781
+msgid ""
+"Would be that more had survived along with me, Eldred. Had I only listened "
+"then to Deoran, been but a little wiser, so many lives might yet have been "
+"saved."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:785
+msgid ""
+"I can never atone for the lives I cost, but I can yet honor them through my "
+"actions. And right now, honoring them means stopping you."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:819
+msgid "NO!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:823
+msgid ""
+"It’s over, Eldred. Down on your knees, now! The rest of you; get back! BACK, "
+"or you’ll have to find yet another king!"
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:827
+msgid ""
+"I didn’t come all this way just to fail now... not at the hand of some cheap "
+"conjurer. No, I prepared for this. After my last defeat, I took... "
+"precautions."
+msgstr ""
+
+#. [message]: speaker=Eldred
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:831
+msgid ""
+"They say this elixir came all the way from the old continent, Delfador. "
+"Persuading Malal to give it up wasn’t easy.\n"
+"\n"
+"You like magic so much? Once I drink from Jevyan’s Cup, I’ll have enough "
+"magic to turn you all to dust!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. liches are skeletal; they don't have blood. This is a consumable artifact of unknown composition, probably captured/extracted from lich-lord Jevyan
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:838
+msgid ""
+"Is that— are you holding <i>lich’s blood</i>!? How— Put it down, Eldred!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:842
+msgid ""
+"Whatever you do, don’t you dare drink it! We have no idea what will happen! "
+"Don’t you dare, Eldred! ELDRED!"
+msgstr ""
+
+#. [unit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:953
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1244
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1460
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1515
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1539
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:86
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:95
+msgid "Eldred"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:971
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Finally.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:976
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Finally, I "
+"understand.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:980
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I can make the pain "
+"all go away. I can make everything better again.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:985
+msgid "...you can?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:997
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>I just need to kill "
+"everyone else first.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1034
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Everything is so "
+"clear now. I see the past; the future.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1038
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your eyes were "
+"clouded. You could not tell the truth from the lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1044
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You still can’t, can "
+"you?</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1217
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>Give up.</span>"
+msgstr ""
+
+#. [chance_to_hit]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1288
+msgid "magical"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1343
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Your king is dead. "
+"Your achievements are undone. Delafdor is a lie.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1475
+msgid "<span color='#CC0000' size='x-small' font_weight='bold'>No.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1509
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>You really still "
+"don’t understand, do you.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1526
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Win or lose, live or "
+"die; nothing you do here matters.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callbacks
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1531
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>Every victory you "
+"ever earned was empty. Everything you ever achieved is undone. The flames of "
+"fear have consumed your world. The future is already written.</span>"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. prophecy callback
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1553
+msgid ""
+"<span color='#CC0000' size='x-small' font_weight='bold'>There is no "
+"greatness within you, mage of Alduin. You are a failure.</span>"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1613
+msgid "I am Delfador."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1617
+msgid "And you are dust."
+msgstr ""
+
+#. [message]
+#. 13 kings is made-up, because 13 is an unlucky number. 12 non-Eldred kings across 500 years makes for an average 42 year reign
+#. given Wesnoth's access to magical healing, a 42-year reign average seems plausible, if rather high.
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1638
+msgid ""
+"Thus perishes Eldred, thirteenth king of Wesnoth.\n"
+"\n"
+"With him ends the story of the sons of Haldric; that unbroken line of kings "
+"stretching five hundred years back to the Green Isle itself."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1644
+msgid ""
+"The exhausted Delfador fights valiantly against Eldred’s — now Asheviere’s — "
+"army, but reinforcements from Weldyn eventually repulse the beleaguered "
+"rebels. Neither side wins a decisive military victory."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1648
+msgid ""
+"As word spreads of the kings’ deaths, a terrible foreboding seems to settle "
+"over the Wesnothian countryside."
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/scenarios/14_Long_Live_the_Queen.cfg:1652
+msgid "After all, the civil war has only just begun..."
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#. "enforder" as in "mob enforcer"
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:6
+msgid "Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Arcane Enforcer, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:20
+msgid ""
+"The harsh, violent life of an outlaw does not readily lend itself to magical "
+"study. Rogue mages who survive their first few years often do so with the "
+"aid of organized bandit gangs, who are more than happy to provide protection "
+"in return for muscle and loyalty. Outfitted with stolen crossbows and "
+"augmenting their piecemeal armor with scraps of half-remembered magic, these "
+"ex-magi brawl with surprising competence, especially under the cover of "
+"darkness."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Arcane_Enforcer.cfg:127
+msgid "female^Arcane Enforcer"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:5
+msgid "Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Rogue Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:19
+msgid ""
+"Not every student has the skill and temperment to become a mage. Novices "
+"often find themselves abandoned by their masters, sometimes for attempting "
+"to practice forbidden arts, but more often for mundane transgressions such "
+"as theft or embezzlement, or even a simple lack of funds.\n"
+"\n"
+"While most of these failed wizards switch to other paths, a driven few turn "
+"to banditry as a way of continuing to fund their independent studies. Now "
+"completely outside the law, Rogue Mages do whatever is necessary to support "
+"themselves, and will often dabble in the use of black magic as a result. "
+"Although they are rarely as skilled as wizards with more formal training, "
+"their spells can still be quite lethal, and their banditry has resulted in "
+"moderate skill with the short sword."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Rogue_Mage.cfg:84
+msgid "female^Rogue Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:5
+msgid "Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Shadow Mage, race=human, gender=male,female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:18
+msgid ""
+"Dabbling in many schools of magic yet fully embracing none, the "
+"impoverished, obsessive study of an independent mage can sometimes yield "
+"impressive results. Unrestrained by the structure of formal apprenticeship, "
+"Shadow Magi have learned to weave together spell and sword, seizing the "
+"secrets of both light and darkness with equal fervor. When the forces of law "
+"or chaos arrive to retaliate, they cloak themselves in shadow and vanish "
+"into the night."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:38
+msgid "chill"
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:39
+msgid ""
+"This attack can deal either blade or cold damage, depending on which would "
+"be more effective."
+msgstr ""
+
+#. [damage_type]: id=cold_damage
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:40
+msgid ""
+"This unit’s melee attack can deal either blade or cold damage, depending on "
+"which would be more effective."
+msgstr ""
+
+#. [female]: gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Bandit_Shadow_Mage.cfg:89
+msgid "female^Shadow Mage"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:5
+msgid "Cave Entrance"
+msgstr ""
+
+#. [unit_type]: id=Cave Entrance, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Cave_Entrance.cfg:15
+msgid ""
+"A crudely hewn passage into the earth, propped open by ageing wooden "
+"supports."
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:4
+msgid "Prince of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=Prince of Wesnoth, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:14
+msgid ""
+"Brothers of a ruling king are traditionally titled ‘Prince’ and bequeathed "
+"wide swathes of land for rulership."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Arand.cfg:28
+msgid "broadsword"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:4
+msgid "Queen"
+msgstr ""
+
+#. [unit_type]: id=Queen, race=human, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg:14
+msgid ""
+"While some queens are influential leaders, many others have their role "
+"restricted to mere social companionship.\n"
+"\n"
+"Nevertheless, even when she does not share political and military power with "
+"the king, a queen can still take part in the kingdom’s internal politics, "
+"both by influencing the royal court and through her kinship with the royal "
+"family."
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:8
+msgid "Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L1, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:12
+msgid ""
+"Humans have often pondered the workings of the world in which they live. "
+"Some endeavor to take this beyond idle musing, to set it as the primary "
+"enterprise of their lives. Any magi worthy of the title have spent at least "
+"a decade in study, amassing a sum of knowledge which sets them apart from "
+"other people. These men and women, who have committed themselves fully to "
+"the pursuit of wisdom, stand in stark contrast to a world where few can even "
+"read and write. Their ranks are filled with the children of hopeful "
+"nobility, or those who sought an escape from the intellectual void of manual "
+"labor.\n"
+"\n"
+"It is an irony that, with all their knowledge, and their unassuming monopoly "
+"thereof, the collective community of magi could likely rule society, were "
+"they ever to try. However, their true love is neither money, nor power, and "
+"those who see the study of magic as a means to such ends often lack the very "
+"conviction required for true mastery.\n"
+"\n"
+"Physically frail, and lacking familiarity with combat, magi do possess "
+"certain arts which are of great utility in battle."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L1.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:29
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:32
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:31
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:45
+msgid "staff"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:8
+msgid "Red Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L2, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L2.cfg:12
+msgid ""
+"Upon the successful culmination of their apprenticeship, a mage is stripped "
+"of the brown robes of an apprentice and given the ruddy cloak of a master. "
+"The significance of this change is often lost on the peasantry, who "
+"mistakenly title Master Magi as ‘Red Magi’. Likewise, the symbolism of the "
+"change in colors is often mistaken to signify the mage’s ability to "
+"seemingly conjure fire from nothing but thin air, a trick which, although "
+"undeniably useful, is viewed by the magi themselves as a crass application "
+"of their hard-won knowledge.\n"
+"\n"
+"Though physically frail, and untrained as warriors, the ‘Red Magi’ have a "
+"number of tricks up their sleeves, including the gouts of fire which may "
+"have cemented their colloquial name."
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:8
+msgid "Arch Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L3, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L3.cfg:12
+msgid ""
+"The title of Arch Mage is traditionally conferred only after a lifetime of "
+"study and achievement to match. Arch Magi are often employed in positions of "
+"education, or as advisors to those sensible enough to seek the fruits of "
+"their wisdom. Many tend to wealthy patrons, a profitable enterprise for both "
+"as, outside of the occasional thaumaturgy or word of advice, it gives the "
+"mage leave to pursue their research undisturbed. From this flows the greater "
+"body of human knowledge; the sciences, the philosophies, and the arts which "
+"give beauty to the world at large.\n"
+"\n"
+"Though not trained for any sort of combat, if need arises an Arch Mage can "
+"unleash the full power of their art, something which is not to be taken "
+"lightly."
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:8
+msgid "Great Mage"
+msgstr ""
+
+#. [unit_type]: id=Delfador L4, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Delfador_L4.cfg:12
+msgid ""
+"Any person who is even considered for the title of Great Mage is quite "
+"nearly a legend in their own time, and town criers have forcibly learnt "
+"discretion in applying the title. Merit for the title is carefully "
+"considered by a council of the leading magi of the age, and the conferment "
+"of the title is given only by a majority vote. Regardless, anyone who is "
+"seriously nominated for the honor of being called a Great Mage is, without "
+"question, a master of their art, and has surpassed almost any of their peers "
+"in skill.\n"
+"\n"
+"Though they are not warriors, by any means, the application of their art to "
+"combat is something that often causes other soldiers to stand aside in awe."
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:8
+msgid "Ambassador"
+msgstr ""
+
+#. [unit_type]: id=Ambassador, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:11
+msgid ""
+"A wise and skilful dignitary may eventually rise to the rank of ambassador "
+"and become an official envoy of Wesnoth. Typically stationed in far-off "
+"nations, these diplomats excel at negotiation and leadership, and have the "
+"authority to broker treaties on behalf of the throne. While they are neither "
+"armed nor authorized for combat, they often know something of the healing "
+"arts."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Ambassador.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:52
+msgid "trample"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:8
+msgid "Veteran Commander"
+msgstr ""
+
+#. [unit_type]: id=Veteran Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:12
+msgid ""
+"After years of war, a nation may find their officer corps suffering from "
+"attrition. In these times of hardship, retired commanders may be called upon "
+"to once again take up their lance and fight in service of their nation. "
+"Having learned from civilian life while still retaining much of their former "
+"military skill, these captains are undeterred by even the most overwhemling "
+"opposition."
+msgstr ""
+
+#. [attack]: type=pierce
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Commander.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:31
+msgid "lance"
+msgstr ""
+
+#. [unit_type]: id=Cavalier Commander, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Deoran_Mirror.cfg:4
+msgid "Cavalier"
+msgstr ""
+
+#. [unit_type]: id=Hunker Eldred, race=human, gender=male
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Hunker.cfg:7
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:4
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:4
+msgid "Crown Prince"
+msgstr ""
+
+#. [unit_type]: id=King Eldred, race=human, gender=male
+#. [unit_type]: id=Crown Prince, race=human, gender=male
+#. [unit_type]: id=Unarmed Eldred, race=human, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:14
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Unarmed.cfg:14
+msgid ""
+"First in the line of succession, a Crown Prince must be ready to take "
+"command at any time should misfortune befall the king. From a young age, "
+"these royal heirs are trained in a variety of combat styles, honing their "
+"skill at whichever weapons they show aptitude for. One uncommon "
+"specialization involves both javelins and swordplay, each weapon covering "
+"the weaknesses of the other."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:28
+msgid "baneblade"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Magic.cfg:32
+msgid "shadow wave"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:27
+msgid "sword"
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Eldred_Prince.cfg:31
+msgid "javelin"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:4
+msgid "King of Wesnoth"
+msgstr ""
+
+#. [unit_type]: id=King of Wesnoth, race=human
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:6
+msgid ""
+"Kings are trained rigorously in the combat arts, sometimes out of necessity, "
+"more often out of tradition from when their priors made their wealth in war. "
+"In battle, a king may wield a sword and lance, riding a steed bred more for "
+"power than for speed. Royalty at the head of a cavalry charge is a "
+"terrifying sight for opposing infantry, and is often enough to break right "
+"through a defensive line."
+msgstr ""
+
+#. [attack]
+#: data/campaigns/The_Deceivers_Gambit/units/Human_Garard.cfg:25
+msgid "longsword"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:4
+msgid "Giant Crab"
+msgstr ""
+
+#. [unit_type]: id=Giant Crab, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:14
+msgid ""
+"Giant crabs are like regular crabs, only giant. Their claws are larger than "
+"a horse’s leg, and their shell is thicker than most armor. But their most "
+"interesting feature is their water spit, which is far more noxious than that "
+"of their smaller cousins."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Crab.cfg:70
+msgid "spit"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:4
+msgid "Eyestalk"
+msgstr ""
+
+#. [unit_type]: id=Eyestalk, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:22
+msgid ""
+"Named ‘Eyestalks’ for obvious reasons, these plant-like creatures can focus "
+"their gaze onto an unsuspecting victim to draw life energy straight out of "
+"them to replenish their own. While readily flammable and almost defenseless "
+"against melee attacks, their deadly gaze from afar is not to be "
+"underestimated."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Eyestalk.cfg:27
+msgid "gaze"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:8
+msgid "Silverback"
+msgstr ""
+
+#. [unit_type]: id=Silverback, race=monster
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:10
+msgid ""
+"The greatest of the apes are the silverbacks, so called for their "
+"distinctive rear coloration. Smaller than an ogre but much more muscular, "
+"the eldest of these creatures are said to possess the strength of a dozen "
+"men."
+msgstr ""
+
+#. [attack]: type=impact
+#: data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg:31
+msgid "fist"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:5
+msgid "Orcish Adept"
+msgstr ""
+
+#. [unit_type]: id=Orcish Adept, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:24
+msgid ""
+"Female orcs with spiritual leanings may find themselves inducted into the "
+"arts of orcish sorcery. Initially called adepts, these newly-trained orcs "
+"gain a curious influence over the shamanistic forces that separate life from "
+"non-life. Directed inwards, this art gives them great resilience against "
+"most forms of magic. Directed outwards, it grants them the fearsome power to "
+"siphon life from their enemies.\n"
+"\n"
+"Although physically frail compared to other orcs this shamanistic art makes "
+"even a freshly trained adept a force to be reckoned with on the battlefield."
+msgstr ""
+
+#. [attack]: type=arcane
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Adept.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:40
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:52
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:875
+msgid "siphon"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:5
+msgid "Orcish Shaman"
+msgstr ""
+
+#. [unit_type]: id=Orcish Shaman, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Shaman.cfg:24
+msgid ""
+"Like most sapient races, orcs often ponder the workings of the world in "
+"which they live. Some endeavor to take this beyond idle musing, but the "
+"violent, nomadic lifestyle of the largest orcish clans does not lend itself "
+"to academic study, and the rare scholarly orc is invariably killed or "
+"enslaved by their more warlike brethren.\n"
+"\n"
+"Orcish shamans are rare exceptions to this rule. Respected among clans and "
+"seen as a trustworthy and neutral party, shamans serve as guardians of "
+"orcish wisdom, and advisors in times of crisis - not something orcs tend to "
+"otherwise tolerate. By the time an adept is recognized as a fully-fledged "
+"shaman, she has committed to memory much of the orcs’ collective oral "
+"tradition. This much-practiced wisdom has many applications, not least of "
+"which is their improved ability to draw life from their foes during battle."
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:5
+msgid "Orcish Sorceress"
+msgstr ""
+
+#. [unit_type]: id=Orcish Sorceress, race=orc, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:24
+msgid ""
+"Orcs are sometimes capable as living as long as humans, but very few "
+"individuals ever fully realize that potential, as the average orc only sees "
+"two or three decades before meeting their end either in battle. Only the "
+"shamans, isolated from the daily strife of the major orcish clans, commonly "
+"live to reach old age.\n"
+"\n"
+"The greatest of these elders make up the Great Council, which may arbitrate "
+"the many conflicts that arise between clans of their argumentative brethren. "
+"Having practiced their mystical art to perfection, these aged orcs are held "
+"in the highest respect across the various clans."
+msgstr ""
+
+#. [attack]: type=arcane
+#: data/campaigns/The_Deceivers_Gambit/units/Orcish_Sorceress.cfg:40
+msgid "sap"
+msgstr ""
+
+#. [unit_type]: id=Beacon, race=mechanical
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Beacon.cfg:5
+msgid "Beacon"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:23
+msgid "Saurian Devotee"
+msgstr ""
+
+#. [unit_type]: id=Saurian Devotee, race=lizard, gender=male
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:37
+msgid ""
+"Saurians have some knowledge of what men call sorcery, but their practice of "
+"it reeks of augury and black magic. It is little understood, but rightly "
+"regarded with fear by those against whom it is used."
+msgstr ""
+
+#. [attack]: type=cold
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg:54
+msgid "curse"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:4
+msgid "Saurian Juvenile"
+msgstr ""
+
+#. [unit_type]: id=Saurian Juvenile, race=lizard
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg:14
+msgid ""
+"Too young, weak, or infirm to hunt or fight, these sauians tend to basic "
+"duties within their clutch."
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:23
+msgid "Saurian Spike"
+msgstr ""
+
+#. [unit_type]: id=Saurian Spike, race=lizard, gender=female
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:37
+msgid ""
+"Saurians are very small of frame, and though they are somewhat frail because "
+"of this, they are very, very agile. In combat, their size allows them to "
+"dart past defenses that would hold any grown man at bay, making them a "
+"tricky foe to deal with."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:45
+msgid "spear"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg:54
+msgid "throwing spear"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:573
+msgid "Kraa!"
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:582
+msgid "Glob glob glob."
+msgstr ""
+
+#. [message]: speaker={UNIT}
+#: data/campaigns/The_Deceivers_Gambit/utils/macros.cfg:591
+msgid "Fsss crackle hiss."
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:61
+msgid "missile"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:219
+msgid "<span color='#ff0000' size='x-small'>No Target</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "Next turn, this unit dies."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:265
+msgid "panacea"
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid ""
+"This unit is a skilled summoner. Adjacent allied elementals deal +100% "
+"damage and gain +100% experience.\n"
+"\n"
+"Summoned elementals dissipate at the end of each scenario."
+msgstr ""
+
+#. [leadership]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:347
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1847
+msgid "summoner"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:483
+msgid "chill touch"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:540
+msgid ""
+"My levitate spell has ended over impassable terrain! I‘m falling to my death!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:619
+msgid "Familiar"
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:659
+msgid ""
+"A familiar already, apprentice? Well done — that’s an impressive piece of "
+"magic even for experienced wizards."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "Whenever an adjacent ally gains xp, you gain the same amount of xp."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:677
+msgid "mnemonic"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1098
+msgid "<span color='#DD6F6F'>counterspelled</span>"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1099
+msgid "Counterspell is nullifying this magical attack."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just cast his Counterspell spell. Magical attacks (including Delfador's) are disabled when near Delfador
+#. explicitly make this a Delfador invention (with a bit of self-fulfilling/recursive prophecy to boot). Don't want counterspell messing up the universe at large
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1197
+msgid ""
+"They called me crazy, but I always knew I could figure out a way to block "
+"magic! I just needed to copy what I— the fake I— did during that prophecy."
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1374
+msgid "consume"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1375
+msgid ""
+"This unit regains <span color='#00FF00'>30%</span> of its maximum hitpoints "
+"whenever it kills a living unit."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1435
+msgid ""
+"My polymorph spell has ended over impassable terrain! I‘m falling to my "
+"death!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just killed a unit while shapeshifted into an animal with his Polymorph spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1458
+msgid ""
+"And so old Methor proves himself right once again — transmutation magic is "
+"<b>not</b> useless!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1593
+msgid "dancing daggers"
+msgstr ""
+
+#. [message]: speaker=unit
+#. Delfador is magically disguised as a drake, and has just case a fireball
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1793
+msgid "Taste drakefire!"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#. Delfador has just saved a unit from lethal damage with the Contingency spell
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1927
+msgid "I’ve got you! You can thank my old master for inventing this spell."
+msgstr ""
+
+#. [message]: speaker=Methor
+#. Methor is probably not here right now to say this line, but he might be
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:1932
+msgid "Well somebody had to! And you’re welcome!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2034
+msgid "lightning"
+msgstr ""
+
+#. [dummy]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2039
+msgid "chain"
+msgstr ""
+
+#. [message]: speaker=$speaker_id
+#. Delfador has just cast his cataclysm spell, dealing heavy damage in a large radius and destroying trees/villages/castles
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2301
+msgid "Dear lords of light, what was that?!"
+msgstr ""
+
+#. [set_menu_item]: id=TDG_spellcasting
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2716
+msgid "Cast Spells"
+msgstr ""
+
+#. [floating_text]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2744
+msgid "<span color='#a308b8' size='small'>Max XP!</span>"
+msgstr ""
+
+#. [message]
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2756
+msgid ""
+"Unlike regular units, Delfador does not use XP to advance. Raising him to "
+"max XP has no effect."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2772
+msgid ""
+"Congratulations on your journeymanship, $unit.name! Those fireballs are "
+"breathtaking! ...now how long until I’m allowed to cast them too?"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg:2783
+msgid ""
+"Congratulations, $unit.name! Your journeyman’s robes look breathtaking. Now "
+"if only Methor would award me mine too ...in red, of course."
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:44
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:51
+msgid "Methor"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:68
+msgid "Arand"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:77
+msgid "Asheviere"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:105
+msgid "Lionel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:119
+msgid "Lord Maddock"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:127
+msgid "Colonel Dommel"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:168
+msgid "Iliah-Malal"
+msgstr ""
+
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:204
+msgid "Garard II"
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:509
+msgid "No, it can’t end yet! I have so much left to do..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:520
+msgid "No! Magic, why have you failed me..."
+msgstr ""
+
+#. [message]: speaker=Delfador
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:531
+msgid "If only I had been a little wiser..."
+msgstr ""
+
+#. [message]: speaker=Methor
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:543
+msgid "War, pain, death... I tried so hard to change things..."
+msgstr ""
+
+#. [message]: speaker=Deoran
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:555
+msgid "I have failed my kingdom and my duty..."
+msgstr ""
+
+#. [message]: speaker=Garard
+#. reference to Shakespeare's Richard III
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:567
+msgid "A horse! A horse! My kingdom for a horse..."
+msgstr ""
+
+#. [message]: speaker=Asheviere
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:577
+msgid "It’s finally over..."
+msgstr ""
+
+#. [message]: speaker=Lionel
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:587
+msgid "Blasted orcs..."
+msgstr ""
+
+#. [message]: speaker=Kalenz
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:599
+msgid "Nobody can cheat death forever..."
+msgstr ""
+
+#. [message]: speaker=Chantal
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:610
+msgid "Deoran, I never had a chance to tell you—"
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:625
+msgid "Boss, I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Lynyan
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:630
+msgid "I ’aint feelin’ too hot..."
+msgstr ""
+
+#. [message]: speaker=Barin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:641
+msgid "I shoulda never left my swamp..."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. since he reappears in HttT's blackwater port, he can't die here.
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:651
+msgid ""
+"I am grievously injured; I can be of no further aid in your quest. Fight on "
+"without me, Delfador!"
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:660
+msgid ""
+"Many Knights choose the path of the Paladin, Delfador, but I am an heir of "
+"the Horse Lords. I shall be a Grand Knight."
+msgstr ""
+
+#. [message]: speaker=Kaylan
+#. Sir Kaylan is a Knight, and has reached max-XP. He reappears in HttT's Blackwater Port, so we need to force him to be a Grand Knight even if the player chooses to advance him to a Paladin
+#: data/campaigns/The_Deceivers_Gambit/utils/unified_characters.cfg:670
+msgid ""
+"I am glad to be a Grand Knight, Delfador. Many Knights choose the path of "
+"the Paladin, but such is unbecoming for an heir of the Horse Lords."
+msgstr ""


### PR DESCRIPTION
Many of the CI builds expect the .po files to already exist, and fail without them.
    
For SCons builds, the .pot file needs to exist, because po/SConscript uses the existing files to find out which textdomains it needs to update.
    
It was already added for CMake, but keeping the list in alphabetical order makes maintenance easier.